### PR TITLE
fix: Webページタイトルの読み上げを純粋な30文字に修正・デフォルトの読み上げ速度を120に変更

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
@@ -115,9 +115,11 @@ public class Event_SpeakVCText extends ListenerAdapter {
             }
 
             String title = getTitle(url);
-            if (title.length() >= 20) {
-                title = title.substring(0, 15);
+            System.out.println("title: " + title);
+            if (title.length() >= 30) {
+                title = title.substring(0, 30) + "以下略";
             }
+            System.out.println("title 2: " + title);
             content = content.replace(url, MessageFormat.format("Webページ「{0}」へのリンク", title));
         }
         return content;
@@ -139,7 +141,7 @@ public class Event_SpeakVCText extends ListenerAdapter {
                     return null;
                 }
                 Matcher m = titlePattern.matcher(body.string());
-                return m.find() ? m.group() : null;
+                return m.find() ? m.group(1) : null;
             }
         } catch (IOException e) {
             return null;

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/ParamCheck.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/ParamCheck.java
@@ -11,12 +11,14 @@ public class ParamCheck {
 
         public toForm(String text, TextChannel channel) {
             String speaktext = text;
-            String speaker = null;
-            int speed = 0;
+
+            // デフォルト値
+            String speaker = "hikari";
+            int speed = 120;
             boolean setEmotion = false;
             String emotion = "";
-            int emotion_lv = 0;
-            int pitch = 0;
+            int emotion_lv = 2;
+            int pitch = 100;
 
             //パラメーターチェック
             for (String s : text.split(" ")) {
@@ -137,19 +139,6 @@ public class ParamCheck {
                         return;
                     }
                 }
-            }
-
-            if (speaker == null) {
-                speaker = "hikari";
-            }
-            if (speed == 0) {
-                speed = 100;
-            }
-            if (pitch == 0) {
-                pitch = 100;
-            }
-            if (emotion_lv == 0) {
-                emotion_lv = 2;
             }
 
             String finalFormatText = MsgFormatter.format(speaktext);


### PR DESCRIPTION
- `<title>`, `</title>` を含んでいてsubstringを間違えてた
- どちらにしても15文字だと少ないので30文字に変更
- デフォルトのスピード読み上げ速度を120に変更した

🙏