### PR TITLE
feat: #4 参加・移動・退出時、チャンネル名から絵文字とかっこ内を削除するように

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
@@ -1,5 +1,6 @@
 package com.jaoafa.jdavcspeaker.Event;
 
+import com.jaoafa.jdavcspeaker.Lib.MsgFormatter;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
 import net.dv8tion.jda.api.entities.User;
@@ -25,7 +26,7 @@ public class Event_Disconnect extends ListenerAdapter {
         VoiceChannel channel = event.getChannelLeft();
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;
         MultipleServer.getVCChannel(event.getGuild()).sendMessage(MessageFormat.format(":outbox_tray: `{0}` が <#{1}> から退出しました。", user.getName(), channel.getId())).queue(
-            message -> VoiceText.speak(message, MessageFormat.format("{0}が{1}から退出しました。", user.getName(), channel.getName()))
+            message -> VoiceText.speak(message, MessageFormat.format("{0}が{1}から退出しました。", user.getName(), MsgFormatter.formatChannelName(channel)))
         );
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
@@ -1,5 +1,6 @@
 package com.jaoafa.jdavcspeaker.Event;
 
+import com.jaoafa.jdavcspeaker.Lib.MsgFormatter;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
 import net.dv8tion.jda.api.entities.User;
@@ -10,6 +11,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import java.text.MessageFormat;
 
 public class Event_Join extends ListenerAdapter {
+
     @Override
     public void onGuildVoiceJoin(GuildVoiceJoinEvent event) {
         if (!MultipleServer.isTargetServer(event.getGuild())) {
@@ -22,7 +24,9 @@ public class Event_Join extends ListenerAdapter {
         VoiceChannel channel = event.getChannelJoined();
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;
         MultipleServer.getVCChannel(event.getGuild()).sendMessage(MessageFormat.format(":inbox_tray: `{0}` が <#{1}> に参加しました。", user.getName(), channel.getId())).queue(
-            message -> VoiceText.speak(message, MessageFormat.format("{0}が{1}に参加しました。", user.getName(), channel.getName()))
+            message -> VoiceText.speak(message, MessageFormat.format("{0}が{1}に参加しました。",
+                user.getName(),
+                MsgFormatter.formatChannelName(channel)))
         );
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
@@ -1,5 +1,6 @@
 package com.jaoafa.jdavcspeaker.Event;
 
+import com.jaoafa.jdavcspeaker.Lib.MsgFormatter;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
 import net.dv8tion.jda.api.entities.User;
@@ -23,7 +24,10 @@ public class Event_Move extends ListenerAdapter {
         VoiceChannel newChannel = event.getNewValue();
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;
         MultipleServer.getVCChannel(event.getGuild()).sendMessage(MessageFormat.format(":twisted_rightwards_arrows: `{0}` が <#{1}> から <#{2}> に移動しました。", user.getName(), oldChannel.getId(), newChannel.getId())).queue(
-            message -> VoiceText.speak(message, MessageFormat.format("{0}が{1}から{2}に移動しました。", user.getName(), oldChannel.getName(), newChannel.getName()))
+            message -> VoiceText.speak(message, MessageFormat.format("{0}が{1}から{2}に移動しました。",
+                user.getName(),
+                MsgFormatter.formatChannelName(oldChannel),
+                MsgFormatter.formatChannelName(newChannel)))
         );
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
@@ -2,11 +2,13 @@ package com.jaoafa.jdavcspeaker.Lib;
 
 import com.jaoafa.jdavcspeaker.StaticData;
 import com.vdurmont.emoji.EmojiParser;
+import net.dv8tion.jda.api.entities.VoiceChannel;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MsgFormatter {
+    static Pattern parenthesesPattern = Pattern.compile("\\(.+\\)");
     public static String format(String text) {
         //LengthCheck
         if (text.length() >= 180) {
@@ -34,9 +36,14 @@ public class MsgFormatter {
         }
 
         final String[] formatText = {text};
-        StaticData.aliasMap.forEach((k, v) -> {
-            formatText[0] = formatText[0].replace(k, v);
-        });
+        StaticData.aliasMap.forEach((k, v) -> formatText[0] = formatText[0].replace(k, v));
         return formatText[0];
+    }
+
+    public static String formatChannelName(VoiceChannel channel) {
+        String channelName = channel.getName();
+        channelName = EmojiParser.removeAllEmojis(channelName); // 絵文字の削除
+        channelName = parenthesesPattern.matcher(channelName).replaceAll(""); // かっこの削除
+        return channelName;
     }
 }


### PR DESCRIPTION
close #4 

`tomachi が 🧀CheeseFactory(WorkingSpace) に参加しました。` -> `tomachi が CheeseFactory に参加しました。`