### PR TITLE
feat: #72 GoLive開始時・終了時に通知する

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GoLiveNotify.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GoLiveNotify.java
@@ -1,0 +1,54 @@
+package com.jaoafa.jdavcspeaker.Event;
+
+import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
+import com.jaoafa.jdavcspeaker.Lib.VoiceText;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceStreamEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.text.MessageFormat;
+
+public class Event_GoLiveNotify extends ListenerAdapter {
+    @Override
+    public void onGuildVoiceStream(GuildVoiceStreamEvent event) {
+        boolean isStream = event.isStream();
+        Member member = event.getMember();
+        VoiceChannel channel = event.getVoiceState().getChannel();
+        if (channel == null) {
+            return;
+        }
+        if (!MultipleServer.isTargetServer(event.getGuild())) {
+            return;
+        }
+        if (event.getGuild().getSelfMember().getVoiceState() == null ||
+            event.getGuild().getSelfMember().getVoiceState().getChannel() == null) {
+            return; // 自身がどのVCにも参加していない
+        }
+        boolean isSpeak = event.getGuild().getSelfMember().getVoiceState().getChannel().getIdLong() == channel.getIdLong();
+        if (MultipleServer.getVCChannel(event.getGuild()) == null) return;
+
+        String text = isStream ?
+            MessageFormat.format(":satellite: `{0}` が <#{1}> でGoLiveを開始しました。",
+                member.getUser().getName(),
+                channel.getId()) :
+            MessageFormat.format(":satellite: `{0}` が <#{1}> でGoLiveを終了しました。",
+                member.getUser().getName(),
+                channel.getId());
+
+        String speakText = isStream ?
+            MessageFormat.format("{0}がGoLiveを開始しました。",
+                member.getUser().getName()) :
+            MessageFormat.format("{0}がGoLiveを終了しました。",
+                member.getUser().getName());
+
+        MultipleServer
+            .getVCChannel(event.getGuild())
+            .sendMessage(text)
+            .queue(
+                message -> {
+                    if (isSpeak) new VoiceText().play(message, speakText);
+                }
+            );
+    }
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdRegister.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdRegister.java
@@ -31,9 +31,11 @@ public class CmdRegister {
 
         //全てのサーバーで登録
         for (Guild guild : jda.getGuilds()) {
-            guild.updateCommands().addCommands(commandList).complete();
-            new LibFlow().success("%sへの登録に成功しました。", guild.getName());
+            guild.updateCommands().addCommands(commandList).queue(
+                s -> new LibFlow().success("%sへの登録に成功しました。", guild.getName()),
+                t -> new LibFlow().error("%sへの登録に失敗しました。(" + t.getMessage() + ")", guild.getName())
+            );
         }
-        new LibFlow().success("全てのGuildに登録しました。");
+        new LibFlow().success("全てのGuildに登録リクエストしました。");
     }
 }


### PR DESCRIPTION
close #72

- 開始時チャット: :satellite: `ユーザ名` が チャンネル名 でGoLiveを開始しました。
- 終了時チャット: :satellite: `ユーザ名` が チャンネル名 でGoLiveを終了しました。
- 開始時発言（同じチャンネル参加中のみ）: ユーザ名がGoLiveを開始しました。
- 終了時発言（同じチャンネル参加中のみ）: ユーザ名がGoLiveを終了しました。
