### PR TITLE
fix: インスペクション

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/CmdExecutor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/CmdExecutor.java
@@ -14,8 +14,8 @@ import net.dv8tion.jda.api.entities.MessageChannel;
 public class CmdExecutor {
     public static void execute(CommandContext<JDACommandSender> context, CmdFunction handler, boolean checkRegistered) {
         MessageChannel channel = context.getSender().getChannel();
-        if (!context.getSender().getEvent().isPresent()) {
-            channel.sendMessage(new EmbedBuilder()
+        if (context.getSender().getEvent().isEmpty()) {
+            channel.sendMessageEmbeds(new EmbedBuilder()
                 .setTitle(":warning: 何かがうまくいきませんでした…")
                 .setDescription("メッセージデータを取得できませんでした。")
                 .setColor(LibEmbedColor.error)
@@ -34,9 +34,5 @@ public class CmdExecutor {
             return;
         }
         handler.execute(guild, channel, member, message, context);
-    }
-
-    public static void execute(CommandContext<JDACommandSender> context, CmdFunction handler) {
-        execute(context, handler, true);
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Alias.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Alias.java
@@ -4,6 +4,7 @@ import com.jaoafa.jdavcspeaker.Framework.Command.CmdDetail;
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdSubstrate;
 import com.jaoafa.jdavcspeaker.Lib.LibAlias;
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
+import com.jaoafa.jdavcspeaker.Main;
 import com.jaoafa.jdavcspeaker.StaticData;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
@@ -46,8 +47,8 @@ public class Cmd_Alias implements CmdSubstrate {
     }
 
     void addAlias(SlashCommandEvent event) {
-        String from = event.getOption("from").getAsString(/*絶対100%確実にRequired*/);
-        String to = event.getOption("to").getAsString(/*絶対100%確実にRequired*/);
+        String from = Main.getExistsOption(event, "from").getAsString();
+        String to = Main.getExistsOption(event, "to").getAsString();
 
         LibAlias.addToAlias(from, to);
 
@@ -60,7 +61,7 @@ public class Cmd_Alias implements CmdSubstrate {
     }
 
     void removeAlias(SlashCommandEvent event) {
-        String from = event.getOption("from").getAsString(/*絶対100%確実にRequired*/);
+        String from = Main.getExistsOption(event, "from").getAsString();
 
         if (!StaticData.aliasMap.containsKey(from)) {
             event.replyEmbeds(new EmbedBuilder()

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Default.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Default.java
@@ -46,7 +46,7 @@ public class Cmd_Default implements CmdSubstrate {
     }
 
     void setUser(User user, SlashCommandEvent event) {
-        String params = event.getOption("params").getAsString(/*絶対100%確実にRequired*/);
+        String params = Main.getExistsOption(event, "params").getAsString();
         VoiceText vt;
         try {
             vt = new VoiceText().parseMessage(params);

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Ignore.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Ignore.java
@@ -4,6 +4,7 @@ import com.jaoafa.jdavcspeaker.Framework.Command.CmdDetail;
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdSubstrate;
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
 import com.jaoafa.jdavcspeaker.Lib.LibIgnore;
+import com.jaoafa.jdavcspeaker.Main;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
@@ -54,7 +55,7 @@ public class Cmd_Ignore implements CmdSubstrate {
     }
 
     void addContains(SlashCommandEvent event) {
-        String text = event.getOption("text").getAsString(/*絶対100%確実にRequired*/);
+        String text = Main.getExistsOption(event, "text").getAsString();
         LibIgnore.addToIgnore("contain", text);
 
         event.replyEmbeds(new EmbedBuilder()
@@ -66,7 +67,7 @@ public class Cmd_Ignore implements CmdSubstrate {
     }
 
     void addEquals(SlashCommandEvent event) {
-        String text = event.getOption("text").getAsString(/*絶対100%確実にRequired*/);
+        String text = Main.getExistsOption(event, "text").getAsString();
         LibIgnore.addToIgnore("equal", text);
 
         event.replyEmbeds(new EmbedBuilder()
@@ -78,7 +79,7 @@ public class Cmd_Ignore implements CmdSubstrate {
     }
 
     void removeContains(SlashCommandEvent event) {
-        String text = event.getOption("text").getAsString(/*絶対100%確実にRequired*/);
+        String text = Main.getExistsOption(event, "text").getAsString();
 
         LibIgnore.removeFromIgnore("contain", text);
 
@@ -91,7 +92,7 @@ public class Cmd_Ignore implements CmdSubstrate {
     }
 
     void removeEquals(SlashCommandEvent event) {
-        String text = event.getOption("text").getAsString(/*絶対100%確実にRequired*/);
+        String text = Main.getExistsOption(event, "text").getAsString();
         LibIgnore.removeFromIgnore("equal", text);
 
         event.replyEmbeds(new EmbedBuilder()

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
@@ -42,7 +42,7 @@ public class Cmd_Title implements CmdSubstrate {
             return;
         }
 
-        String new_title = event.getOption("title").getAsString(/*絶対100%確実にRequired*/);
+        String new_title = Main.getExistsOption(event, "title").getAsString();
         VoiceChannel targetVC = member.getVoiceState().getChannel();
 
         LibTitle libTitle = Main.getLibTitle();

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_VCSpeaker.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_VCSpeaker.java
@@ -4,11 +4,11 @@ import com.jaoafa.jdavcspeaker.Framework.Command.CmdDetail;
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdSubstrate;
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
+import com.jaoafa.jdavcspeaker.Main;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
@@ -18,7 +18,7 @@ import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
 import java.util.Optional;
 
 public class Cmd_VCSpeaker implements CmdSubstrate {
-    EmbedBuilder NOPERMISSION =
+    final EmbedBuilder NO_PERMISSION =
         new EmbedBuilder()
             .setDescription("""
                 あなたは管理者権限を所持していないため、
@@ -53,14 +53,14 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
                        SlashCommandEvent event, String subCmd) {
         switch (subCmd) {
             case "server:add" -> addServer(guild, channel, member, event);
-            case "server:notify" -> addServer(guild, channel, member, event);
-            case "server:remove" -> addServer(guild, channel, member, event);
+            case "server:notify" -> removeServer(guild, member, event);
+            case "server:remove" -> setNotifyChannel(guild, channel, member, event);
         }
     }
 
     void addServer(Guild guild, MessageChannel channel, Member member, SlashCommandEvent event) {
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
-            event.replyEmbeds(NOPERMISSION.build()).queue();
+            event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
         }
         if (MultipleServer.isTargetServer(guild)) {
@@ -80,8 +80,7 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
                 .addServer(
                     guild,
                     Optional.ofNullable(
-                        event
-                            .getOption("channel")
+                        Main.getExistsOption(event, "channel")
                             .getAsMessageChannel()
                     ).orElse(channel)
                 );
@@ -100,7 +99,7 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
 
     void removeServer(Guild guild, Member member, SlashCommandEvent event) {
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
-            event.replyEmbeds(NOPERMISSION.build()).queue();
+            event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
         }
         if (!MultipleServer.isTargetServer(guild)) {
@@ -123,7 +122,7 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
     void setNotifyChannel(Guild guild, MessageChannel channel, Member member, SlashCommandEvent event) {
 
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
-            event.replyEmbeds(NOPERMISSION.build()).queue();
+            event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
         }
         if (MultipleServer.isNotifiable(guild)) {
@@ -142,8 +141,7 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
             MultipleServer
                 .setNotifyChannel(guild,
                     Optional.ofNullable(
-                        event
-                            .getOption("channel")
+                        Main.getExistsOption(event, "channel")
                             .getAsMessageChannel()
                     ).orElse(channel)
                 );

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoDisconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoDisconnect.java
@@ -45,6 +45,6 @@ public class AutoDisconnect extends ListenerAdapter {
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle(":white_check_mark: AutoDisconnected")
             .setColor(LibEmbedColor.success);
-        MultipleServer.getVCChannel(event.getGuild()).sendMessage(embed.build()).queue();
+        MultipleServer.getVCChannel(event.getGuild()).sendMessageEmbeds(embed.build()).queue();
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoJoin.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoJoin.java
@@ -31,6 +31,6 @@ public class AutoJoin extends ListenerAdapter {
             .setTitle(":white_check_mark: AutoJoin")
             .setDescription(MessageFormat.format("<#{0}> に接続しました。", event.getChannelJoined().getId()))
             .setColor(LibEmbedColor.success);
-        MultipleServer.getVCChannel(event.getGuild()).sendMessage(embed.build()).queue();
+        MultipleServer.getVCChannel(event.getGuild()).sendMessageEmbeds(embed.build()).queue();
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoMove.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoMove.java
@@ -60,6 +60,6 @@ public class AutoMove extends ListenerAdapter {
             .setTitle(":white_check_mark: AutoMoved")
             .setDescription(MessageFormat.format("<#{0}> から <#{1}> に移動しました。", connectedChannel.getId(), newChannel.getId()))
             .setColor(LibEmbedColor.success);
-        MultipleServer.getVCChannel(event.getGuild()).sendMessage(embed.build()).queue();
+        MultipleServer.getVCChannel(event.getGuild()).sendMessageEmbeds(embed.build()).queue();
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GeneralNotify.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GeneralNotify.java
@@ -79,7 +79,7 @@ public class Event_GeneralNotify extends ListenerAdapter {
             .setTitle(":inbox_tray: 会話が始まりました！")
             .setDescription(MessageFormat.format("{0} が <#{1}> に参加しました。", event.getMember().getAsMention(), event.getChannelJoined().getId()))
             .setColor(LibEmbedColor.normal);
-        MultipleServer.getNotifyChannel(event.getGuild()).sendMessage(embed.build()).queue(
+        MultipleServer.getNotifyChannel(event.getGuild()).sendMessageEmbeds(embed.build()).queue(
             message -> {
                 try {
                     Files.write(notify_id_path, Collections.singleton(message.getId()));

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
@@ -76,7 +76,7 @@ public class Event_SpeakVCText extends ListenerAdapter {
                         .setTitle(":white_check_mark: AutoJoined")
                         .setDescription("`" + member.getVoiceState().getChannel().getName() + "`へ自動接続しました。")
                         .setColor(LibEmbedColor.success);
-                    MultipleServer.getVCChannel(event.getGuild()).sendMessage(embed.build()).queue();
+                    MultipleServer.getVCChannel(event.getGuild()).sendMessageEmbeds(embed.build()).queue();
                 }
             } else {
                 return; // 自身がどこにも入っておらず、送信者もどこにも入っていない場合
@@ -240,21 +240,9 @@ public class Event_SpeakVCText extends ListenerAdapter {
         }
     }
 
-    static class UserVoiceTextResult {
-        final VoiceText vt;
-        final boolean isReset;
-
-        public UserVoiceTextResult(VoiceText vt, boolean isReset) {
-            this.vt = vt;
-            this.isReset = isReset;
-        }
-
+    record UserVoiceTextResult(VoiceText vt, boolean isReset) {
         public VoiceText getVoiceText() {
             return vt;
-        }
-
-        public boolean isReset() {
-            return isReset;
         }
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdRegister.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdRegister.java
@@ -11,19 +11,19 @@ import java.util.ArrayList;
 
 public class CmdRegister {
     public CmdRegister(JDA jda) {
-        new LibFlow().header("PublicCommand").setName("PublicCmd");
+        new LibFlow().header("PublicCommand").setName("PublicCmd").run();
         ArrayList<CommandData> commandList = new ArrayList<>();
         try {
             for (Class<?> cmdClass : new LibClassFinder().findClasses("com.jaoafa.jdavcspeaker.Command")) {
                 if (!cmdClass.getSimpleName().startsWith("Cmd_")
                     || cmdClass.getEnclosingClass() != null
                     || cmdClass.getName().contains("$")) {
-                    new LibFlow().error("%sはCommandクラスではありません。スキップします...", cmdClass.getSimpleName());
+                    new LibFlow().error("%sはCommandクラスではありません。スキップします...", cmdClass.getSimpleName()).run();
                     continue;
                 }
                 CmdSubstrate cmd = (CmdSubstrate) cmdClass.getConstructor().newInstance();
                 commandList.add(cmd.detail().getData());
-                new LibFlow().success("%sを登録キューに挿入しました。", cmdClass.getSimpleName());
+                new LibFlow().success("%sを登録キューに挿入しました。", cmdClass.getSimpleName()).run();
             }
         } catch (Exception e) {
             new LibReporter(null, e);
@@ -32,8 +32,8 @@ public class CmdRegister {
         //全てのサーバーで登録
         for (Guild guild : jda.getGuilds()) {
             guild.updateCommands().addCommands(commandList).complete();
-            new LibFlow().success("%sへの登録に成功しました。", guild.getName());
+            new LibFlow().success("%sへの登録に成功しました。", guild.getName()).run();
         }
-        new LibFlow().success("全てのGuildに登録しました。");
+        new LibFlow().success("全てのGuildに登録しました。").run();
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Framework/Event/EventRegister.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Framework/Event/EventRegister.java
@@ -15,14 +15,14 @@ public class EventRegister {
                 if (!eventClass.getSimpleName().startsWith("Event_")
                     || eventClass.getEnclosingClass() != null
                     || eventClass.getName().contains("$")) {
-                    new LibFlow().error("%sはEventクラスではありません。スキップします...", eventClass.getSimpleName());
+                    new LibFlow().error("%sはEventクラスではありません。スキップします...", eventClass.getSimpleName()).run();
                     continue;
                 }
 
                 Object instance = ((Constructor<?>) eventClass.getConstructor()).newInstance();
                 if (instance instanceof ListenerAdapter) {
                     jdaBuilder.addEventListeners(instance);
-                    new LibFlow().success("%sを登録しました。", eventClass.getSimpleName());
+                    new LibFlow().success("%sを登録しました。", eventClass.getSimpleName()).run();
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Framework/FunctionHooker.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Framework/FunctionHooker.java
@@ -12,9 +12,9 @@ import org.json.JSONObject;
 import java.lang.reflect.InvocationTargetException;
 
 public class FunctionHooker extends ListenerAdapter {
-    String ROOT_PACKAGE = "com.jaoafa.jdavcspeaker";
-    String CMD_PACKAGE = "Command";
-    String ACT_PACKAGE = "Action";
+    final String ROOT_PACKAGE = "com.jaoafa.jdavcspeaker";
+    final String CMD_PACKAGE = "Command";
+    final String ACT_PACKAGE = "Action";
 
     @Override
     public void onSlashCommand(@NotNull SlashCommandEvent event) {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/CmdBuilders.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/CmdBuilders.java
@@ -6,12 +6,9 @@ import cloud.commandframework.jda.JDACommandSender;
 import java.util.Arrays;
 import java.util.List;
 
-public class CmdBuilders {
-    private final Command<JDACommandSender>[] commands;
-
+public record CmdBuilders(Command<JDACommandSender>... commands) {
     @SafeVarargs
-    public CmdBuilders(Command<JDACommandSender>... commands) {
-        this.commands = commands;
+    public CmdBuilders {
     }
 
     /**

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibEmbedColor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibEmbedColor.java
@@ -3,8 +3,8 @@ package com.jaoafa.jdavcspeaker.Lib;
 import java.awt.*;
 
 public class LibEmbedColor {
-    public static Color error = new Color(255, 110, 110);
-    public static Color cation = new Color(255, 178, 110);
-    public static Color success = new Color(132, 199, 118);
-    public static Color normal = new Color(206, 132, 196);
+    public static final Color error = new Color(255, 110, 110);
+    public static final Color cation = new Color(255, 178, 110);
+    public static final Color success = new Color(132, 199, 118);
+    public static final Color normal = new Color(206, 132, 196);
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibFlow.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibFlow.java
@@ -1,47 +1,64 @@
 package com.jaoafa.jdavcspeaker.Lib;
 
 
+import javax.annotation.CheckReturnValue;
+import java.util.LinkedList;
+
 import static com.jaoafa.jdavcspeaker.Lib.LibTextColor.*;
 
 public class LibFlow {
     private static String actionName;
+    private final LinkedList<String> messages = new LinkedList<>();
 
     private String getPrefix(String symbol, String color) {
         return String.format("|%s%s%s|[%s%s%s] ", color, symbol, RESET, BLUE_BRIGHT, actionName, RESET);
     }
 
+    @CheckReturnValue
     public LibFlow setName(String name) {
         actionName = name;
         return this;
     }
 
+    @CheckReturnValue
     public LibFlow header(String name, String... format) {
-        System.out.printf("===// %s%s%s //\n", YELLOW, String.format(name, (Object[]) format), RESET);
+        messages.add("===// " + YELLOW + name.formatted((Object[]) format) + RESET + " //===");
         return this;
     }
 
+    @CheckReturnValue
     public LibFlow task(String task, String... format) {
-        System.out.println(getPrefix(">", BLUE) + String.format(task, (Object[]) format));
+        messages.add(getPrefix(">", BLUE) + task.formatted((Object[]) format));
         return this;
     }
 
+    @CheckReturnValue
     public LibFlow action(String action, String... format) {
-        System.out.println(getPrefix("*", PURPLE) + String.format(action, (Object[]) format));
+        messages.add(getPrefix("*", PURPLE) + action.formatted((Object[]) format));
         return this;
     }
 
+    @CheckReturnValue
     public LibFlow success(String success, String... format) {
-        System.out.println(getPrefix("+", GREEN_BRIGHT) + String.format(success, (Object[]) format));
+        messages.add(getPrefix("+", GREEN_BRIGHT) + success.formatted((Object[]) format));
         return this;
     }
 
+    @CheckReturnValue
     public LibFlow error(String error, String... format) {
-        System.out.println(getPrefix("#", RED) + String.format(error, (Object[]) format));
+        messages.add(getPrefix("#", RED) + error.formatted((Object[]) format));
         return this;
     }
 
+    @CheckReturnValue
     public LibFlow pipe() {
-        System.out.printf("|%s|%s|\n", CYAN, RESET);
+        messages.add("|" + CYAN + "|" + RESET + "|");
         return this;
+    }
+
+    public void run() {
+        for (String message : messages) {
+            System.out.println(message);
+        }
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibJson.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibJson.java
@@ -34,27 +34,6 @@ public class LibJson {
     }
 
     /**
-     * JSONファイルを配列として読み出します。
-     *
-     * @param _path JSONファイルへのパス
-     * @return JSON配列
-     * @throws IOException          入出力例外が発生した場合
-     * @throws JSONException        JSONとして正しくないなど、パースできなかった場合
-     * @throws InvalidPathException パス文字列をPathに変換できない場合
-     */
-    /*
-    public static JSONArray readArray(String _path) throws IOException, JSONException, InvalidPathException {
-        Path path = Paths.get(_path);
-        JSONArray array = new JSONArray();
-        if (!Files.exists(path)) {
-            return array;
-        }
-        String json = String.join("\n", Files.readAllLines(path, Charset.defaultCharset()));
-        return new JSONArray(json);
-    }
-    */
-
-    /**
      * オブジェクトをJSONファイルに書き出します。
      *
      * @param path   書き出すJSONファイルのパス
@@ -66,20 +45,6 @@ public class LibJson {
     public static void writeObject(String path, JSONObject object) throws IOException, InvalidPathException {
         Files.write(Paths.get(path), Collections.singleton(object.toString()));
     }
-
-    /**
-     * 配列をJSONファイルに書き出します。
-     *
-     * @param path  書き出すJSONファイルのパス
-     * @param array 書き出す配列
-     * @throws IOException          入出力例外が発生した場合
-     * @throws InvalidPathException パス文字列をPathに変換できない場合
-     */
-    /*
-    public static void writeArray(String path, JSONArray array) throws IOException, InvalidPathException {
-        Files.write(Paths.get(path), Collections.singleton(array.toString()));
-    }
-    */
 
     /**
      * JSONObjectのString値をパスで検索します。

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibReporter.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibReporter.java
@@ -14,7 +14,7 @@ public class LibReporter {
                 stacktrace.append(stackTraceElement.getClassName()).append("\n");
 
             String stacktraceString = stacktrace.length() > 900 ? stacktrace.substring(0, 800) : stacktrace.toString();
-            channel.sendMessage(new EmbedBuilder()
+            channel.sendMessageEmbeds(new EmbedBuilder()
                 .setTitle(":loudspeaker: 例外が発生しました！")
                 .addField(":pencil: メッセージ", "```\n%s\n```".formatted(e.getMessage()), false)
                 .addField(":boom: 原因", "```\n%s\n```".formatted(e.getCause()), false)

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTextColor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTextColor.java
@@ -2,16 +2,16 @@ package com.jaoafa.jdavcspeaker.Lib;
 
 public class LibTextColor {
     // Reset
-    public static String RESET = "\033[0m";  // Text Reset
+    public static final String RESET = "\033[0m";  // Text Reset
 
     // Regular Colors
     public static String BLACK = "\033[0;30m";   // BLACK
-    public static String RED = "\033[0;31m";     // RED
+    public static final String RED = "\033[0;31m";     // RED
     public static String GREEN = "\033[0;32m";   // GREEN
-    public static String YELLOW = "\033[0;33m";  // YELLOW
-    public static String BLUE = "\033[0;34m";    // BLUE
-    public static String PURPLE = "\033[0;35m";  // PURPLE
-    public static String CYAN = "\033[0;36m";    // CYAN
+    public static final String YELLOW = "\033[0;33m";  // YELLOW
+    public static final String BLUE = "\033[0;34m";    // BLUE
+    public static final String PURPLE = "\033[0;35m";  // PURPLE
+    public static final String CYAN = "\033[0;36m";    // CYAN
     public static String WHITE = "\033[0;37m";   // WHITE
 
     // Bold
@@ -47,9 +47,9 @@ public class LibTextColor {
     // High Intensity
     public static String BLACK_BRIGHT = "\033[0;90m";  // BLACK
     public static String RED_BRIGHT = "\033[0;91m";    // RED
-    public static String GREEN_BRIGHT = "\033[0;92m";  // GREEN
+    public static final String GREEN_BRIGHT = "\033[0;92m";  // GREEN
     public static String YELLOW_BRIGHT = "\033[0;93m"; // YELLOW
-    public static String BLUE_BRIGHT = "\033[0;94m";   // BLUE
+    public static final String BLUE_BRIGHT = "\033[0;94m";   // BLUE
     public static String PURPLE_BRIGHT = "\033[0;95m"; // PURPLE
     public static String CYAN_BRIGHT = "\033[0;96m";   // CYAN
     public static String WHITE_BRIGHT = "\033[0;97m";  // WHITE

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTitle.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTitle.java
@@ -54,10 +54,12 @@ public class LibTitle {
     public Boolean checkTitleIsSame(VoiceChannel channel) {
         if (titleSetting == null) return false;
         if (!titleSetting.has(channel.getId())) return false;
+        String original_title = getOriginalTitle(channel);
+        if (original_title == null) return false;
         //Title使用中だったら中止
         if (isModifiedTitle(channel)) return null;
 
-        return getOriginalTitle(channel).equals(channel.getName());
+        return original_title.equals(channel.getName());
     }
 
     /**

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
@@ -44,6 +44,7 @@ public class MsgFormatter {
 
         // URLCheck
         for (String s : splitText) {
+            //noinspection HttpUrlsUsage
             if (s.startsWith("https://") || s.startsWith("http://")) {
                 String[] urlSplit = s.split("/");
                 text = text.replace(s, urlSplit[urlSplit.length - 1]);

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -253,14 +253,14 @@ public class VoiceText {
                 .filter(s -> !s.equals(VoiceText.Speaker.__WRONG__))
                 .map(Enum::name)
                 .collect(Collectors.joining("`, `"));
-            message.reply(new EmbedBuilder()
+            message.replyEmbeds(new EmbedBuilder()
                 .setTitle(":bangbang: メッセージパラメーターが不正")
                 .setDescription(String.format("`speaker` が正しくありません。使用可能なパラメーターは `%s` です。", allowParams))
                 .setColor(LibEmbedColor.error)
                 .build()).queue();
             return;
         } catch (WrongSpeedException e) {
-            message.reply(new EmbedBuilder()
+            message.replyEmbeds(new EmbedBuilder()
                 .setTitle(":bangbang: メッセージパラメーターが不正")
                 .setDescription(String.format("`speed` が正しくありません。使用可能なパラメーターは `%s` です。", "50 ～ 400"))
                 .setColor(LibEmbedColor.error)
@@ -271,7 +271,7 @@ public class VoiceText {
                 .filter(s -> !s.equals(VoiceText.Emotion.__WRONG__))
                 .map(Enum::name)
                 .collect(Collectors.joining("`, `"));
-            message.reply(new EmbedBuilder()
+            message.replyEmbeds(new EmbedBuilder()
                 .setTitle(":bangbang: メッセージパラメーターが不正")
                 .setDescription(String.format("`emotion` が正しくありません。使用可能なパラメーターは `%s` です。", allowParams))
                 .setColor(LibEmbedColor.error)
@@ -282,14 +282,14 @@ public class VoiceText {
                 .filter(s -> !s.equals(VoiceText.EmotionLevel.__WRONG__))
                 .map(Enum::name)
                 .collect(Collectors.joining("`, `"));
-            message.reply(new EmbedBuilder()
+            message.replyEmbeds(new EmbedBuilder()
                 .setTitle(":bangbang: メッセージパラメーターが不正")
                 .setDescription(String.format("`emotionLevel` が正しくありません。使用可能なパラメーターは `%s` です。", allowParams))
                 .setColor(LibEmbedColor.error)
                 .build()).queue();
             return;
         } catch (WrongPitchException e) {
-            message.reply(new EmbedBuilder()
+            message.replyEmbeds(new EmbedBuilder()
                 .setTitle(":bangbang: メッセージパラメーターが不正")
                 .setDescription(String.format("`pitch` が正しくありません。使用可能なパラメーターは `%s` です。", "50 ～ 200"))
                 .setColor(LibEmbedColor.error)

--- a/src/main/java/com/jaoafa/jdavcspeaker/Main.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Main.java
@@ -11,8 +11,9 @@ import com.jaoafa.jdavcspeaker.Lib.*;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.events.ReadyEvent;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
@@ -38,13 +39,14 @@ public class Main extends ListenerAdapter {
     static VisionAPI visionAPI = null;
     static LibTitle libTitle = null;
     static String speakToken = null;
-    static String prefix = "/";
+    static final String prefix = "/";
 
     public static void main(String[] args) {
         new LibFlow()
             .setName("BootStrap")
             .header("VCSpeaker StartUp")
-            .action("設定を読み込み中...");
+            .action("設定を読み込み中...")
+            .run();
 
         //Task: Config読み込み
 
@@ -53,7 +55,7 @@ public class Main extends ListenerAdapter {
         try {
             config = LibJson.readObject("./VCSpeaker.json");
         } catch (Exception e) {
-            new LibFlow().error("基本設定の読み込みに失敗しました。");
+            new LibFlow().error("基本設定の読み込みに失敗しました。").run();
             new LibReporter(null, e);
             System.exit(1);
             return;
@@ -66,7 +68,7 @@ public class Main extends ListenerAdapter {
 
         //SubTask: Tokenクラスが無かったら終了
         if (!config.has("Token")) {
-            new LibFlow().error(missingDetectionMsg.apply("Tokenクラス"));
+            new LibFlow().error(missingDetectionMsg.apply("Tokenクラス")).run();
             System.exit(1);
             return;
         } else {
@@ -75,12 +77,12 @@ public class Main extends ListenerAdapter {
 
         //SubTask: DiscordTokenの欠落を検知
         if (!config.getJSONObject("Token").has("Discord")) {
-            new LibFlow().error(missingDetectionMsg.apply("DiscordToken"));
+            new LibFlow().error(missingDetectionMsg.apply("DiscordToken")).run();
             missingConfigDetected = true;
         }
         //SubTask: SpeakerTokenの欠落を検知
         if (!config.getJSONObject("Token").has("Speaker")) {
-            new LibFlow().error(missingDetectionMsg.apply("SpeakerToken"));
+            new LibFlow().error(missingDetectionMsg.apply("SpeakerToken")).run();
             missingConfigDetected = true;
         }
 
@@ -125,7 +127,7 @@ public class Main extends ListenerAdapter {
         try {
             jda = builder.build().awaitReady();
         } catch (InterruptedException | LoginException e) {
-            new LibFlow().error("Discordへのログインに失敗しました。");
+            new LibFlow().error("Discordへのログインに失敗しました。").run();
             new LibReporter(null, e);
             System.exit(1);
             return;
@@ -137,7 +139,7 @@ public class Main extends ListenerAdapter {
             try {
                 visionAPI = new VisionAPI(tokenConfig.getString("VisionAPI"));
             } catch (Exception e) {
-                new LibFlow().error("VisionAPIの初期化に失敗しました。関連機能は動作しません。");
+                new LibFlow().error("VisionAPIの初期化に失敗しました。関連機能は動作しません。").run();
                 new LibReporter(null, e);
                 visionAPI = null;
             }
@@ -146,7 +148,7 @@ public class Main extends ListenerAdapter {
         try {
             libTitle = new LibTitle("./title.json");
         } catch (Exception e) {
-            new LibFlow().error("タイトル設定の読み込みに失敗しました。関連機能は動作しません。");
+            new LibFlow().error("タイトル設定の読み込みに失敗しました。関連機能は動作しません。").run();
             new LibReporter(null, e);
             System.exit(1);
             return;
@@ -221,5 +223,14 @@ public class Main extends ListenerAdapter {
         LibAlias.fetchMap();
         LibIgnore.fetchMap();
         System.out.println("VCSPEAKER!!!!!!!!!!!!!!!!!!!!STARTED!!!!!!!!!!!!:tada::tada:");
+    }
+
+    @NotNull
+    public static OptionMapping getExistsOption(SlashCommandEvent event, String name) {
+        OptionMapping option = event.getOption(name);
+        if (option == null) {
+            throw new IllegalArgumentException();
+        }
+        return option;
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackInfo.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackInfo.java
@@ -3,13 +3,7 @@ package com.jaoafa.jdavcspeaker.Player;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 
-public class TrackInfo {
-    private final Message message;
-
-    public TrackInfo(Message message) {
-        this.message = message;
-    }
-
+public record TrackInfo(Message message) {
     public Message getMessage() {
         return message;
     }
@@ -17,5 +11,4 @@ public class TrackInfo {
     public TextChannel getChannel() {
         return message.getTextChannel();
     }
-
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
@@ -54,11 +54,7 @@ public class TrackScheduler extends AudioEventAdapter {
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         if (endReason.mayStartNext) {
-            if (!(track.getUserData() instanceof TrackInfo)) {
-                return;
-            }
-            TrackInfo info = (TrackInfo) track.getUserData();
-            if (info == null) {
+            if (!(track.getUserData() instanceof TrackInfo info)) {
                 return;
             }
 
@@ -87,11 +83,7 @@ public class TrackScheduler extends AudioEventAdapter {
     }
 
     void reactionSpeaking(AudioTrack track) {
-        if (!(track.getUserData() instanceof TrackInfo)) {
-            return;
-        }
-        TrackInfo info = (TrackInfo) track.getUserData();
-        if (info == null) {
+        if (!(track.getUserData() instanceof TrackInfo info)) {
             return;
         }
         TextChannel channel = StaticData.jda.getTextChannelById(info.getChannel().getIdLong());


### PR DESCRIPTION
## Java 16サポート、依存パッケージアップデートに伴う修正

- `record` の使用 (参考: https://docs.oracle.com/javase/jp/15/language/records.html)
- パターン変数の使用 (参考: https://www.ne.jp/asahi/hishidama/home/tech/java/preview/instanceof.14.html)
- `Optional.isEmpty` の使用
- `TextChannel.sendMessage(MessageEmbed)` から `TextChannel.sendMessageEmbeds(MessageEmbed)` へ変更
- `Message.reply(MessageEmbed)` から `Message.replyEmbeds(MessageEmbed)` へ変更

## IntelliJ インスペクション警告の修正

- `SlashCommandEvent.getOption(String)` の返り値が Nullable なために発生する NullPointerException 対策: `Main.getExistsOption` を作成して置き換え
- `final` に変更できる変数を `final` に変更

## バグの修正

- `/vcspeaker server *` コマンドが正常に動いていない不具合の修正

## 仕様変更

- LibFlowクラスの仕様変更
  - 各関数に `@CheckReturnValue` を指定し、最終的に `.run();` しなければならないように（関数チェーン）
  - `String.format` から `String.formatted` へ変更

## その他

- 使用されていない関数の削除