### PR TITLE
feat: alias parseコマンドの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ JDA + Lavaplayer で作られている VCSpeaker のリポジトリです。
 - `alias add from:<from> to:<to>`: `<from>` を `<to>` に置き換えるように設定します。
 - `alias remove from:<from>`: `<from>` の置き換えを削除します。
 - `alias list`: 置き換え(エイリアス)一覧を取得します。
+- `alias parse text:<text>`: `<text>` に対して設定済みのエイリアスを適用したテキストを返します
 
 ### `clear`: 読み上げキュー削除
 

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Alias.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Alias.java
@@ -30,7 +30,9 @@ public class Cmd_Alias implements CmdSubstrate {
                             .addOption(OptionType.STRING, "to", "変換先テキスト", true),
                         new SubcommandData("remove", "エイリアスを削除します")
                             .addOption(OptionType.STRING, "from", "変換を削除するテキスト", true),
-                        new SubcommandData("list", "エイリアス一覧を表示します")
+                        new SubcommandData("list", "エイリアス一覧を表示します"),
+                        new SubcommandData("parse", "エイリアスを適用したテキストを返します")
+                            .addOption(OptionType.STRING, "text", "エイリアスを適用するテキスト", true)
                     )
             );
     }
@@ -44,6 +46,7 @@ public class Cmd_Alias implements CmdSubstrate {
             case "add" -> addAlias(event);
             case "remove" -> removeAlias(event);
             case "list" -> listAlias(event);
+            case "parse" -> parseAlias(event);
         }
     }
 
@@ -96,6 +99,21 @@ public class Cmd_Alias implements CmdSubstrate {
         event.replyEmbeds(new EmbedBuilder()
             .setTitle(":bookmark_tabs: 現在のエイリアス")
             .setDescription(list)
+            .setColor(LibEmbedColor.success)
+            .build()
+        ).queue();
+    }
+
+    void parseAlias(SlashCommandEvent event) {
+        String orig_text = Main.getExistsOption(event, "text").getAsString();
+        String text = orig_text;
+
+        for (Map.Entry<String, String> entry : StaticData.aliasMap.entrySet()) {
+            text = text.replace(entry.getKey(), entry.getValue());
+        }
+
+        event.replyEmbeds(new EmbedBuilder()
+            .setDescription("`%s` -> `%s`".formatted(orig_text, text))
             .setColor(LibEmbedColor.success)
             .build()
         ).queue();


### PR DESCRIPTION
- `alias parse text:<text>`: `<text>` に対して設定済みのエイリアスを適用したテキストを返します