### PR TITLE
fix: 音声データの保存ハッシュ生成データ方式の修正

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -306,7 +306,7 @@ public class VoiceText {
         System.out.println(this);
 
         String formattedText = MsgFormatter.format(speakText);
-        String hash = DigestUtils.md5Hex("%s_%s_%d_%s_%s_%d".formatted(speakText,
+        String hash = DigestUtils.md5Hex("%s_%s_%d_%s_%s_%d".formatted(formattedText,
             speaker.name(),
             speed,
             emotion != null ? emotion.name() : "null",


### PR DESCRIPTION
主にエイリアス関連の不具合

エイリアスをかけて、そのエイリアステキストを読ませた後、エイリアスを削除し再度読ませようとするとエイリアスがかかった文章が読まれてしまうという不具合の修正。
ハッシュ値の生成元データをフォーマット済みテキストにすることで修正