### PR TITLE
feat/fix: 機能追加 + 修正

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Alias.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Alias.java
@@ -55,6 +55,7 @@ public class Cmd_Alias implements CmdSubstrate {
         String to = Main.getExistsOption(event, "to").getAsString();
 
         LibAlias.addToAlias(from, to);
+        cmdFlow.success("%s がエイリアスを設定しました: %s -> %s", event.getUser().getAsTag(), from, to);
 
         event.replyEmbeds(new EmbedBuilder()
             .setTitle(":pencil: エイリアスを設定しました！")
@@ -81,6 +82,7 @@ public class Cmd_Alias implements CmdSubstrate {
         }
 
         LibAlias.removeFromAlias(from);
+        cmdFlow.success("%s がエイリアスを削除しました: %s -> %s", event.getUser().getAsTag(), from);
 
         event.replyEmbeds(new EmbedBuilder()
             .setTitle(":wastebasket: エイリアスを削除しました！")

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Clear.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Clear.java
@@ -31,8 +31,10 @@ public class Cmd_Clear implements CmdSubstrate {
     void clear(Guild guild, SlashCommandEvent event) {
         PlayerManager.getINSTANCE().getGuildMusicManager(guild).scheduler.queue.clear();
         PlayerManager.getINSTANCE().getGuildMusicManager(guild).player.destroy();
+
+        cmdFlow.success("%s が読み上げキューをクリアしました。", event.getUser().getAsTag());
         event.replyEmbeds(new EmbedBuilder()
-            .setTitle(":stop_button: 読み上げをクリアしました！")
+            .setTitle(":stop_button: 読み上げキューをクリアしました！")
             .setColor(LibEmbedColor.success)
             .build()
         ).queue();

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Disconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Disconnect.java
@@ -51,6 +51,7 @@ public class Cmd_Disconnect implements CmdSubstrate {
         }
 
         guild.getAudioManager().closeAudioConnection();
+        cmdFlow.success("%s が %s から切断するようリクエストしました。", event.getUser().getAsTag(), connectedChannel.getName());
 
         event.replyEmbeds(new EmbedBuilder()
             .setTitle(":wave: 切断しました！")

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Restart.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Restart.java
@@ -30,6 +30,7 @@ public class Cmd_Restart implements CmdSubstrate {
 
 
     void restart(Guild guild, SlashCommandEvent event) {
+        cmdFlow.action("%s のリクエストにより、VCSpeakerを再起動します。", event.getUser().getAsTag());
         event.replyEmbeds(new EmbedBuilder()
             .setTitle(":wave: 再起動します")
             .setColor(LibEmbedColor.success)

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Skip.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Skip.java
@@ -16,7 +16,7 @@ public class Cmd_Skip implements CmdSubstrate {
         return new CmdDetail()
             .setEmoji(":broom:")
             .setData(
-                new CommandData(this.getClass().getSimpleName().substring(4).toLowerCase(), "現在の読み上げをキャンセルします")
+                new CommandData(this.getClass().getSimpleName().substring(4).toLowerCase(), "現在の読み上げをキャンセル（スキップ）します")
             );
     }
 
@@ -30,6 +30,7 @@ public class Cmd_Skip implements CmdSubstrate {
 
     void skip(Guild guild, SlashCommandEvent event) {
         PlayerManager.getINSTANCE().getGuildMusicManager(guild).scheduler.nextTrack();
+        cmdFlow.success("%s がスキップしました。", event.getUser().getAsTag());
         event.replyEmbeds(new EmbedBuilder()
             .setTitle(":track_next: 読み上げをスキップします")
             .setColor(LibEmbedColor.success)

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Summon.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Summon.java
@@ -51,6 +51,7 @@ public class Cmd_Summon implements CmdSubstrate {
         }
 
         guild.getAudioManager().openAudioConnection(connectedChannel);
+        cmdFlow.success("%s が %s に接続するようリクエストしました。", event.getUser().getAsTag(), connectedChannel.getName());
 
         event.replyEmbeds(new EmbedBuilder()
             .setDescription(":satellite: <#%s> に接続しました。".formatted(connectedChannel.getId()))

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
@@ -6,6 +6,7 @@ import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
 import com.jaoafa.jdavcspeaker.Lib.LibTitle;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
 import com.jaoafa.jdavcspeaker.Main;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
@@ -71,7 +72,7 @@ public class Cmd_Title implements CmdSubstrate {
             ).queue();
             return;
         }
-
+        cmdFlow.success("%s がChannel ID: %s のVC名を変更しました: %s -> %s", event.getUser().getAsTag(), member.getVoiceState().getChannel().getId(), old_title, new_title);
 
         event.replyEmbeds(new EmbedBuilder()
             .setTitle(":magic_wand: タイトルを変更しました！")
@@ -83,8 +84,11 @@ public class Cmd_Title implements CmdSubstrate {
             .build()
         ).queue(
             msg -> msg.retrieveOriginal().queue(
-                origin_msg -> new VoiceText()
-                    .play(origin_msg, String.format("タイトルを%sに変更しました", new_title))
+                origin_msg -> new VoiceText().play(
+                    TrackInfo.SpeakFromType.CHANGED_TITLE,
+                    origin_msg,
+                    String.format("タイトルを%sに変更しました", new_title)
+                )
             )
         );
     }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Vcspeaker.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Vcspeaker.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
@@ -17,7 +18,7 @@ import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
 
 import java.util.Optional;
 
-public class Cmd_VCSpeaker implements CmdSubstrate {
+public class Cmd_Vcspeaker implements CmdSubstrate {
     final EmbedBuilder NO_PERMISSION =
         new EmbedBuilder()
             .setDescription("""
@@ -75,16 +76,15 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
             return;
         }
 
+        OptionMapping channelOpt = event.getOption("channel");
         boolean isSuccessful =
             MultipleServer
                 .addServer(
                     guild,
-                    Optional.ofNullable(
-                        Main.getExistsOption(event, "channel")
-                            .getAsMessageChannel()
-                    ).orElse(channel)
+                    channelOpt != null ? channelOpt.getAsMessageChannel() : channel
                 );
 
+        cmdFlow.success("%s がサーバ登録をリクエストしました: %s", event.getUser().getAsTag(), isSuccessful ? "成功" : "失敗");
         event.replyEmbeds(new EmbedBuilder()
             .setTitle("サーバーの登録に%sしました".formatted(isSuccessful ? "成功" : "失敗"))
             .setDescription(
@@ -112,6 +112,7 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
         }
         boolean isSuccessful = MultipleServer.removeServer(guild) && MultipleServer.removeNotifyChannel(guild);
 
+        cmdFlow.success("%s がサーバ登録解除をリクエストしました: %s", event.getUser().getAsTag(), isSuccessful ? "成功" : "失敗");
         event.replyEmbeds(new EmbedBuilder()
             .setDescription("このサーバの登録解除に%sしました".formatted(isSuccessful ? "成功" : "失敗"))
             .setColor(LibEmbedColor.error)
@@ -120,7 +121,6 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
     }
 
     void setNotifyChannel(Guild guild, MessageChannel channel, Member member, SlashCommandEvent event) {
-
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
             event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
@@ -146,6 +146,7 @@ public class Cmd_VCSpeaker implements CmdSubstrate {
                     ).orElse(channel)
                 );
 
+        cmdFlow.success("%s が通知チャンネルの設定をリクエストしました: %s", event.getUser().getAsTag(), isSuccessful ? "成功" : "失敗");
         event.replyEmbeds(new EmbedBuilder()
             .setTitle("通知チャンネルの登録に%sしました".formatted(isSuccessful ? "成功" : "失敗"))
             .setDescription(

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoDisconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoDisconnect.java
@@ -1,12 +1,11 @@
 package com.jaoafa.jdavcspeaker.Event;
 
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
+import com.jaoafa.jdavcspeaker.Lib.LibFlow;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-
-import java.text.MessageFormat;
 
 /**
  * If someone disconnects, it will also exit itself if there are no users other than the bot.
@@ -31,14 +30,11 @@ public class AutoDisconnect extends ListenerAdapter {
             .getMembers()
             .stream()
             .anyMatch(member -> !member.getUser().isBot()); // Bot以外がいるかどうか
-        System.out.println(MessageFormat.format("[AutoDisconnect] {0}: {1} -> {2}",
-            event.getMember().getUser().getAsTag(),
-            event.getChannelLeft().getName(),
-            !existsUser));
 
         if (existsUser) {
             return;
         }
+        new LibFlow("AutoDisconnect").success("退出に伴い、VCから誰もいなくなったため切断します。");
         event.getGuild().getAudioManager().closeAudioConnection();
 
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoJoin.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoJoin.java
@@ -1,6 +1,7 @@
 package com.jaoafa.jdavcspeaker.Event;
 
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
+import com.jaoafa.jdavcspeaker.Lib.LibFlow;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent;
@@ -27,6 +28,8 @@ public class AutoJoin extends ListenerAdapter {
         audioManager.openAudioConnection(event.getChannelJoined());
 
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;
+
+        new LibFlow("AutoJoin").success("自動接続しました: %s", event.getChannelJoined().getName());
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle(":white_check_mark: AutoJoin")
             .setDescription(MessageFormat.format("<#{0}> に接続しました。", event.getChannelJoined().getId()))

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoMove.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoMove.java
@@ -1,6 +1,7 @@
 package com.jaoafa.jdavcspeaker.Event;
 
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
+import com.jaoafa.jdavcspeaker.Lib.LibFlow;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.VoiceChannel;
@@ -56,6 +57,8 @@ public class AutoMove extends ListenerAdapter {
         audioManager.openAudioConnection(event.getChannelJoined());
 
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;
+
+        new LibFlow("AutoJoin").success("自動移動しました: %s -> %s", connectedChannel.getName(), newChannel.getName());
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle(":white_check_mark: AutoMoved")
             .setDescription(MessageFormat.format("<#{0}> から <#{1}> に移動しました。", connectedChannel.getId(), newChannel.getId()))

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_DeletedMessage.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_DeletedMessage.java
@@ -1,0 +1,42 @@
+package com.jaoafa.jdavcspeaker.Event;
+
+import com.jaoafa.jdavcspeaker.Lib.LibFlow;
+import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
+import com.jaoafa.jdavcspeaker.Player.GuildMusicManager;
+import com.jaoafa.jdavcspeaker.Player.PlayerManager;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageDeleteEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+public class Event_DeletedMessage extends ListenerAdapter {
+    @Override
+    public void onGuildMessageDelete(@NotNull GuildMessageDeleteEvent event) {
+        if (!MultipleServer.isTargetServer(event.getGuild())) {
+            return;
+        }
+        final Guild guild = event.getGuild();
+        final long messageId = event.getMessageIdLong();
+        GuildMusicManager musicManager = PlayerManager.getINSTANCE().getGuildMusicManager(guild);
+
+        new LibFlow("DeletedMessage").action("メッセージ(ID: " + messageId + ")が削除されました。");
+
+        // キューにあるトラックが削除されたメッセージであるか
+        musicManager.scheduler.queue.removeIf(track -> {
+            if (!(track.getUserData() instanceof TrackInfo info)) {
+                return false;
+            }
+            return info.getMessage().getIdLong() == messageId;
+        });
+
+        // 再生中のトラックが削除されたメッセージであるか
+        AudioTrack playingTrack = musicManager.scheduler.player.getPlayingTrack();
+        if (playingTrack != null &&
+            playingTrack.getUserData() instanceof TrackInfo info
+            && info.getMessage().getIdLong() == messageId) {
+            musicManager.scheduler.nextTrack();
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
@@ -5,6 +5,7 @@ import com.jaoafa.jdavcspeaker.Lib.MsgFormatter;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
 import com.jaoafa.jdavcspeaker.Main;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent;
@@ -42,10 +43,13 @@ public class Event_Disconnect extends ListenerAdapter {
                 channel.getId()))
             .queue(
                 message ->
-                    new VoiceText().play(message,
+                    new VoiceText().play(
+                        TrackInfo.SpeakFromType.QUITED_VC,
+                        message,
                         MessageFormat.format("{0}が{1}から退出しました。",
                             user.getName(),
-                            MsgFormatter.formatChannelName(channel)))
+                            MsgFormatter.formatChannelName(channel))
+                    )
             );
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GoLiveNotify.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GoLiveNotify.java
@@ -2,6 +2,7 @@ package com.jaoafa.jdavcspeaker.Event;
 
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceStreamEvent;
@@ -47,7 +48,13 @@ public class Event_GoLiveNotify extends ListenerAdapter {
             .sendMessage(text)
             .queue(
                 message -> {
-                    if (isSpeak) new VoiceText().play(message, speakText);
+                    if (isSpeak) {
+                        new VoiceText().play(
+                            isStream ? TrackInfo.SpeakFromType.STARTED_GOLIVE : TrackInfo.SpeakFromType.ENDED_GOLIVE,
+                            message,
+                            speakText
+                        );
+                    }
                 }
             );
     }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
@@ -3,6 +3,7 @@ package com.jaoafa.jdavcspeaker.Event;
 import com.jaoafa.jdavcspeaker.Lib.MsgFormatter;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent;
@@ -31,10 +32,13 @@ public class Event_Join extends ListenerAdapter {
             .queue(
                 message ->
                     new VoiceText()
-                        .play(message,
+                        .play(
+                            TrackInfo.SpeakFromType.JOINED_VC,
+                            message,
                             MessageFormat.format("{0}が{1}に参加しました。",
                                 user.getName(),
-                                MsgFormatter.formatChannelName(channel)))
+                                MsgFormatter.formatChannelName(channel))
+                        )
             );
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
@@ -5,6 +5,7 @@ import com.jaoafa.jdavcspeaker.Lib.MsgFormatter;
 import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
 import com.jaoafa.jdavcspeaker.Lib.VoiceText;
 import com.jaoafa.jdavcspeaker.Main;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceMoveEvent;
@@ -41,12 +42,14 @@ public class Event_Move extends ListenerAdapter {
                 newChannel.getId()))
             .queue(
                 message ->
-                    new VoiceText()
-                        .play(message,
-                            MessageFormat.format("{0}が{1}から{2}に移動しました。",
-                                user.getName(),
-                                MsgFormatter.formatChannelName(oldChannel),
-                                MsgFormatter.formatChannelName(newChannel)))
+                    new VoiceText().play(
+                        TrackInfo.SpeakFromType.MOVED_VC,
+                        message,
+                        MessageFormat.format("{0}が{1}から{2}に移動しました。",
+                            user.getName(),
+                            MsgFormatter.formatChannelName(oldChannel),
+                            MsgFormatter.formatChannelName(newChannel))
+                    )
             );
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
@@ -2,6 +2,7 @@ package com.jaoafa.jdavcspeaker.Event;
 
 import com.jaoafa.jdavcspeaker.Lib.*;
 import com.jaoafa.jdavcspeaker.Main;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import com.jaoafa.jdavcspeaker.StaticData;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
@@ -85,12 +86,8 @@ public class Event_SpeakVCText extends ListenerAdapter {
         }
 
         // ignore
-        boolean ignoreEquals = StaticData.ignoreMap.entrySet().stream()
-            .anyMatch(entry -> entry.getKey().equals("equal") &&
-                content.equals(entry.getValue()));
-        boolean ignoreContain = StaticData.ignoreMap.entrySet().stream()
-            .anyMatch(entry -> entry.getKey().equals("contain") &&
-                content.contains(entry.getValue()));
+        boolean ignoreEquals = StaticData.ignoreEquals.contains(content);
+        boolean ignoreContain = StaticData.ignoreContains.stream().anyMatch(content::contains);
 
         if (ignoreEquals || ignoreContain) return;
 
@@ -112,13 +109,13 @@ public class Event_SpeakVCText extends ListenerAdapter {
             message.reply("デフォルトパラメーターが不正であるため、リセットしました。").queue();
         }
         VoiceText vt = isEmphasize ? changeEmphasizeSpeed(uvtr.getVoiceText()) : uvtr.getVoiceText();
-        vt.play(message, speakContent);
+        vt.play(TrackInfo.SpeakFromType.RECEIVED_MESSAGE, message, speakContent);
 
         // 画像等
         VisionAPI visionAPI = Main.getVisionAPI();
         if (visionAPI == null) {
             message.getAttachments()
-                .forEach(attachment -> vt.play(message, "ファイル「" + attachment.getFileName() + "」が送信されました。"));
+                .forEach(attachment -> vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "ファイル「" + attachment.getFileName() + "」が送信されました。"));
             return;
         }
         if (!new File("tmp").exists()) {
@@ -132,7 +129,7 @@ public class Event_SpeakVCText extends ListenerAdapter {
                     boolean bool = file.delete();
                     System.out.println("Temp attachment file have been delete " + (bool ? "successfully" : "failed"));
                     if (results == null) {
-                        vt.play(message, "ファイル「" + attachment.getFileName() + "」が送信されました。");
+                        vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "ファイル「" + attachment.getFileName() + "」が送信されました。");
                         return;
                     }
 
@@ -144,7 +141,7 @@ public class Event_SpeakVCText extends ListenerAdapter {
                         .map(s -> s.length() > 15 ? s.substring(0, 15) : s)
                         .limit(3)
                         .collect(Collectors.joining("、"));
-                    vt.play(message, "画像ファイル「" + descriptions + "を含む画像」が送信されました。");
+                    vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「" + descriptions + "を含む画像」が送信されました。");
 
                     String text = sortedResults.stream()
                         .filter(r -> r.getType() == VisionAPI.ResultType.TEXT_DETECTION)

--- a/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdRegister.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdRegister.java
@@ -11,19 +11,20 @@ import java.util.ArrayList;
 
 public class CmdRegister {
     public CmdRegister(JDA jda) {
-        new LibFlow().header("PublicCommand").setName("PublicCmd").run();
+        LibFlow cmdRegisterFlow = new LibFlow("CmdRegister");
+        cmdRegisterFlow.header("Command Register");
         ArrayList<CommandData> commandList = new ArrayList<>();
         try {
             for (Class<?> cmdClass : new LibClassFinder().findClasses("com.jaoafa.jdavcspeaker.Command")) {
                 if (!cmdClass.getSimpleName().startsWith("Cmd_")
                     || cmdClass.getEnclosingClass() != null
                     || cmdClass.getName().contains("$")) {
-                    new LibFlow().error("%sはCommandクラスではありません。スキップします...", cmdClass.getSimpleName()).run();
+                    cmdRegisterFlow.error("%sはCommandクラスではありません。スキップします...", cmdClass.getSimpleName());
                     continue;
                 }
                 CmdSubstrate cmd = (CmdSubstrate) cmdClass.getConstructor().newInstance();
                 commandList.add(cmd.detail().getData());
-                new LibFlow().success("%sを登録キューに挿入しました。", cmdClass.getSimpleName()).run();
+                cmdRegisterFlow.success("%sを登録キューに挿入しました。", cmdClass.getSimpleName());
             }
         } catch (Exception e) {
             new LibReporter(null, e);
@@ -32,11 +33,10 @@ public class CmdRegister {
         //全てのサーバーで登録
         for (Guild guild : jda.getGuilds()) {
             guild.updateCommands().addCommands(commandList).queue(
-                s -> new LibFlow().success("%sへの登録に成功しました。", guild.getName()),
-                t -> new LibFlow().error("%sへの登録に失敗しました。(" + t.getMessage() + ")", guild.getName())
+                s -> cmdRegisterFlow.success("%sへの登録に成功しました。", guild.getName()),
+                t -> cmdRegisterFlow.error("%sへの登録に失敗しました。(" + t.getMessage() + ")", guild.getName())
             );
         }
-        new LibFlow().success("全てのGuildに登録リクエストしました。");
-
+        cmdRegisterFlow.success("全てのGuildにコマンドの登録をリクエストしました。");
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdSubstrate.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Framework/Command/CmdSubstrate.java
@@ -1,10 +1,13 @@
 package com.jaoafa.jdavcspeaker.Framework.Command;
 
+import com.jaoafa.jdavcspeaker.Lib.LibFlow;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 public interface CmdSubstrate {
+    LibFlow cmdFlow = new LibFlow("Command");
+
     CmdDetail detail();
 
     void hooker(JDA jda, Guild guild, MessageChannel channel, ChannelType type, Member member, User user, SlashCommandEvent event, String subCmd);

--- a/src/main/java/com/jaoafa/jdavcspeaker/Framework/Event/EventRegister.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Framework/Event/EventRegister.java
@@ -10,19 +10,21 @@ import java.lang.reflect.Constructor;
 
 public class EventRegister {
     public EventRegister(JDABuilder jdaBuilder) {
+        LibFlow eventRegisterFlow = new LibFlow("EventRegister");
+        eventRegisterFlow.header("Event Register");
         try {
             for (Class<?> eventClass : new LibClassFinder().findClasses("com.jaoafa.jdavcspeaker.Event")) {
                 if (!eventClass.getSimpleName().startsWith("Event_")
                     || eventClass.getEnclosingClass() != null
                     || eventClass.getName().contains("$")) {
-                    new LibFlow().error("%sはEventクラスではありません。スキップします...", eventClass.getSimpleName()).run();
+                    eventRegisterFlow.error("%sはEventクラスではありません。スキップします...", eventClass.getSimpleName());
                     continue;
                 }
 
                 Object instance = ((Constructor<?>) eventClass.getConstructor()).newInstance();
                 if (instance instanceof ListenerAdapter) {
                     jdaBuilder.addEventListeners(instance);
-                    new LibFlow().success("%sを登録しました。", eventClass.getSimpleName()).run();
+                    eventRegisterFlow.success("%sを登録しました。", eventClass.getSimpleName());
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibAlias.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibAlias.java
@@ -13,16 +13,20 @@ import java.util.List;
 
 public class LibAlias {
     public static void fetchMap() {
+        LibFlow aliasFlow = new LibFlow("LibAlias");
         File aliasConfig = new File("./alias.json");
         //存在しない場合に作成
         if (!aliasConfig.exists()) {
             try {
                 Files.write(Paths.get("alias.json"), Collections.singleton(new JSONObject().toString()));
+                aliasFlow.success("alias.json ファイルの作成に成功しました。");
             } catch (IOException e) {
+                aliasFlow.error("alias.json ファイルの作成に失敗しました。");
                 e.printStackTrace();
             }
         }
 
+        StaticData.aliasMap.clear();
         try {
             List<String> lines = Files.readAllLines(Paths.get("alias.json"));
             JSONObject obj = new JSONObject(String.join("\n", lines));
@@ -31,7 +35,9 @@ public class LibAlias {
                 String key = it.next();
                 StaticData.aliasMap.put(key, obj.getString(key));
             }
+            aliasFlow.success("エイリアス設定を " + StaticData.aliasMap.size() + " 件ロードしました。");
         } catch (IOException e) {
+            aliasFlow.error("除外設定のロード中にエラーが発生しました。");
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibFlow.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibFlow.java
@@ -2,63 +2,39 @@ package com.jaoafa.jdavcspeaker.Lib;
 
 
 import javax.annotation.CheckReturnValue;
-import java.util.LinkedList;
 
 import static com.jaoafa.jdavcspeaker.Lib.LibTextColor.*;
 
-public class LibFlow {
-    private static String actionName;
-    private final LinkedList<String> messages = new LinkedList<>();
+public record LibFlow(String actionName) {
+    @CheckReturnValue
+    public LibFlow {
+    }
 
     private String getPrefix(String symbol, String color) {
         return String.format("|%s%s%s|[%s%s%s] ", color, symbol, RESET, BLUE_BRIGHT, actionName, RESET);
     }
 
-    @CheckReturnValue
-    public LibFlow setName(String name) {
-        actionName = name;
-        return this;
+    public void header(String name, String... format) {
+        System.out.println("===// " + YELLOW + name.formatted((Object[]) format) + RESET + " //===");
     }
 
-    @CheckReturnValue
-    public LibFlow header(String name, String... format) {
-        messages.add("===// " + YELLOW + name.formatted((Object[]) format) + RESET + " //===");
-        return this;
+    public void task(String task, String... format) {
+        System.out.println(getPrefix(">", BLUE) + task.formatted((Object[]) format));
     }
 
-    @CheckReturnValue
-    public LibFlow task(String task, String... format) {
-        messages.add(getPrefix(">", BLUE) + task.formatted((Object[]) format));
-        return this;
+    public void action(String action, String... format) {
+        System.out.println(getPrefix("*", PURPLE) + action.formatted((Object[]) format));
     }
 
-    @CheckReturnValue
-    public LibFlow action(String action, String... format) {
-        messages.add(getPrefix("*", PURPLE) + action.formatted((Object[]) format));
-        return this;
+    public void success(String success, String... format) {
+        System.out.println(getPrefix("+", GREEN_BRIGHT) + success.formatted((Object[]) format));
     }
 
-    @CheckReturnValue
-    public LibFlow success(String success, String... format) {
-        messages.add(getPrefix("+", GREEN_BRIGHT) + success.formatted((Object[]) format));
-        return this;
+    public void error(String error, String... format) {
+        System.out.println(getPrefix("#", RED) + error.formatted((Object[]) format));
     }
 
-    @CheckReturnValue
-    public LibFlow error(String error, String... format) {
-        messages.add(getPrefix("#", RED) + error.formatted((Object[]) format));
-        return this;
-    }
-
-    @CheckReturnValue
-    public LibFlow pipe() {
-        messages.add("|" + CYAN + "|" + RESET + "|");
-        return this;
-    }
-
-    public void run() {
-        for (String message : messages) {
-            System.out.println(message);
-        }
+    public void pipe() {
+        System.out.println("|" + CYAN + "|" + RESET + "|");
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibIgnore.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibIgnore.java
@@ -8,37 +8,48 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 public class LibIgnore {
     public static void fetchMap() {
+        LibFlow ignoreFlow = new LibFlow("LibIgnore");
         File ignoreConfig = new File("./ignore.json");
         //存在しない場合に作成
         if (!ignoreConfig.exists()) {
             try {
                 Files.write(Paths.get("ignore.json"), Collections.singleton(new JSONObject().toString()));
+                ignoreFlow.success("ignore.json ファイルの作成に成功しました。");
             } catch (IOException e) {
+                ignoreFlow.error("ignore.json ファイルの作成に失敗しました。");
                 e.printStackTrace();
             }
         }
+
+        StaticData.ignoreContains.clear();
+        StaticData.ignoreEquals.clear();
 
         try {
             List<String> lines = Files.readAllLines(Paths.get("ignore.json"));
             JSONObject obj = new JSONObject(String.join("\n", lines));
 
-            for (Iterator<String> it = obj.keys(); it.hasNext(); ) {
-                String key = it.next();
-                StaticData.ignoreMap.put(key, obj.getString(key));
+            for (int i = 0; i < obj.getJSONArray("contain").length(); i++) {
+                StaticData.ignoreContains.add(obj.getJSONArray("contain").getString(i));
             }
+            for (int i = 0; i < obj.getJSONArray("equal").length(); i++) {
+                StaticData.ignoreEquals.add(obj.getJSONArray("equal").getString(i));
+            }
+            ignoreFlow.success("除外設定をロードしました（含む: %d / 一致: %d）。".formatted(StaticData.ignoreContains.size(), StaticData.ignoreEquals.size()));
         } catch (IOException e) {
+            ignoreFlow.error("除外設定のロード中にエラーが発生しました。");
+            new LibReporter(null, e);
             e.printStackTrace();
         }
     }
 
     public static void saveJson() {
         JSONObject obj = new JSONObject();
-        StaticData.ignoreMap.forEach(obj::put);
+        obj.put("contain", StaticData.ignoreContains);
+        obj.put("equal", StaticData.ignoreEquals);
         try {
             Files.write(Paths.get("ignore.json"), Collections.singleton(obj.toString()));
         } catch (IOException e) {
@@ -46,13 +57,23 @@ public class LibIgnore {
         }
     }
 
-    public static void addToIgnore(String value1, String value2) {
-        StaticData.ignoreMap.put(value1, value2);
+    public static void addToContainIgnore(String value) {
+        StaticData.ignoreContains.add(value);
         saveJson();
     }
 
-    public static void removeFromIgnore(String value1, String value2) {
-        StaticData.ignoreMap.remove(value1, value2);
+    public static void addToEqualIgnore(String value) {
+        StaticData.ignoreEquals.add(value);
+        saveJson();
+    }
+
+    public static void removeToContainIgnore(String value) {
+        StaticData.ignoreContains.remove(value);
+        saveJson();
+    }
+
+    public static void removeToEqualIgnore(String value) {
+        StaticData.ignoreEquals.remove(value);
         saveJson();
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -398,13 +398,14 @@ public class VoiceText {
             if (!(track.getUserData() instanceof TrackInfo info)) {
                 return false;
             }
-            return filterRule.contains(info.getSpeakFromType());
+            return filterRule.contains(info.getSpeakFromType()) && info.getUser().getIdLong() == message.getAuthor().getIdLong();
         });
         // 再生中のトラックがフィルタルールに合致するか
         AudioTrack playingTrack = musicManager.scheduler.player.getPlayingTrack();
         if (playingTrack != null &&
-            playingTrack.getUserData() instanceof TrackInfo info
-            && filterRule.contains(info.getSpeakFromType())) {
+            playingTrack.getUserData() instanceof TrackInfo info &&
+            filterRule.contains(info.getSpeakFromType()) &&
+            info.getUser().getIdLong() == message.getAuthor().getIdLong()) {
             musicManager.scheduler.nextTrack();
         }
     }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackInfo.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackInfo.java
@@ -2,13 +2,51 @@ package com.jaoafa.jdavcspeaker.Player;
 
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
 
-public record TrackInfo(Message message) {
+public record TrackInfo(SpeakFromType speakFromType, Message message) {
     public Message getMessage() {
         return message;
     }
 
+    public User getUser() {
+        return message.getAuthor();
+    }
+
     public TextChannel getChannel() {
         return message.getTextChannel();
+    }
+
+    public SpeakFromType getSpeakFromType() {
+        return speakFromType;
+    }
+
+    @Override
+    public String toString() {
+        return "TrackInfo{" +
+            "speakFromType=" + speakFromType +
+            ", message=" + message +
+            '}';
+    }
+
+    public enum SpeakFromType {
+        /** 通常メッセージが送信された */
+        RECEIVED_MESSAGE,
+        /** ファイルが送信された */
+        RECEIVED_FILE,
+        /** 画像が送信された */
+        RECEIVED_IMAGE,
+        /** VCにユーザーが参加した */
+        JOINED_VC,
+        /** VCでユーザーが移動した */
+        MOVED_VC,
+        /** VCからユーザーが退出した */
+        QUITED_VC,
+        /** GoLiveを開始した */
+        STARTED_GOLIVE,
+        /** GoLiveを終了した */
+        ENDED_GOLIVE,
+        /** VCタイトルを変えた */
+        CHANGED_TITLE
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
@@ -17,7 +17,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  */
 public class TrackScheduler extends AudioEventAdapter {
     public final BlockingQueue<AudioTrack> queue;
-    private final AudioPlayer player;
+    public final AudioPlayer player;
 
     /**
      * @param player The audio player this scheduler uses

--- a/src/main/java/com/jaoafa/jdavcspeaker/StaticData.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/StaticData.java
@@ -2,11 +2,14 @@ package com.jaoafa.jdavcspeaker;
 
 import net.dv8tion.jda.api.JDA;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class StaticData {
     public static final Map<String, String> aliasMap = new HashMap<>();
-    public static final Map<String, String> ignoreMap = new HashMap<>();
+    public static final List<String> ignoreContains = new ArrayList<>();
+    public static final List<String> ignoreEquals = new ArrayList<>();
     public static JDA jda;
 }


### PR DESCRIPTION
コミット分けるべきなんだけど、一つ始めたら連鎖的に修正しなきゃならんくなって分離できなかった…

## 自動読み上げキャンセルの追加

`Lib/VoiceText` の filteringQueue 関数で定義

- VC退出時、参加・移動メッセージ読み上げを削除する
- GoLive終了時、GoLive開始読み上げを削除する
- タイトル変更時、タイトル変更通知読み上げを削除する（最新変更のみ通知）

の三つを追加したけど、テストした限りうまく動いているか微妙だった…。

あと、削除されたメッセージの読み上げをキャンセルする機能も追加。

## 読み上げの理由種別を設定

自動読み上げキャンセルの追加に伴い、TrackInfo クラスに SpeakFromType 定数クラスを追加。

- `RECEIVED_MESSAGE`: 通常メッセージが送信された
- `RECEIVED_FILE`: ファイルが送信された
- `RECEIVED_IMAGE`: 画像が送信された
- `JOINED_VC`: VCにユーザーが参加した
- `MOVED_VC`: VCでユーザーが移動した
- `QUITED_VC`: VCからユーザーが退出した
- `STARTED_GOLIVE`: GoLiveを開始した
- `ENDED_GOLIVE`: GoLiveを終了した
- `CHANGED_TITLE`: VCタイトルを変えた

## 登録済みコマンドを削除する引数 --only-remove-cmd の追加

`java -jar jdavcspeaker-jar-with-dependencies.jar --only-remove-cmd` で登録済みコマンドをすべて削除してアプリケーションを終了する処理を行えるように。
動作テストをして最後にこれ実行しておけば本番環境に必要以上の被害を出さなくて済む

## ignore不具合の修正

キーを `contain` と `equal` にしているせいで正常動作してないように見えたので、独立したリストで保持するように変更

## vcspeakerコマンドが動作しない不具合の修正

スラッシュコマンドを実行されたときの呼び出しクラス構築でミスってるのかわからんけどうまく動かなかったので、とりあえずクラス名を変更