### PR TITLE
fix: #86 alias remove時に発生するformatエラーの修正、alias listをページネーションに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ JDA + Lavaplayer で作られている VCSpeaker のリポジトリです。
 
 - `alias add from:<from> to:<to>`: `<from>` を `<to>` に置き換えるように設定します。
 - `alias remove from:<from>`: `<from>` の置き換えを削除します。
-- `alias list`: 置き換え(エイリアス)一覧を取得します。
+- `alias list`: 置き換え(エイリアス)一覧を表示します。
+- `alias list page:<page>`: `<page>` ページの置き換え(エイリアス)一覧を表示します。
 - `alias parse text:<text>`: `<text>` に対して設定済みのエイリアスを適用したテキストを返します
 
 ### `clear`: 読み上げキュー削除


### PR DESCRIPTION
close #86 

- #86 `/alias remove from:xxxx` 実行時に `java.util.MissingFormatArgumentException: Format specifier '%s'` が発生する問題の修正
- `/alias list page:n` の実装（実装が非常に汚いので今後リファクタリング）
- 上記実装に伴うREADME.mdの変更