### PR TITLE
feat: #94 titleコマンド実行時、新タイトルに絵文字が含まれていなかったら最初に絵文字を入れる

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GeneralNotify.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GeneralNotify.java
@@ -67,7 +67,7 @@ public class Event_GeneralNotify extends ListenerAdapter {
 
         if (Files.exists(notify_id_path)) {
             try {
-                String last_notify_id = String.join("\n", Files.readAllLines(notify_id_path));
+                String last_notify_id = Files.readString(notify_id_path);
                 //noinspection ResultOfMethodCallIgnored
                 MultipleServer.getNotifyChannel(event.getGuild()).retrieveMessageById(last_notify_id).queue(Message::delete);
             } catch (IOException e) {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/DefaultParamsManager.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/DefaultParamsManager.java
@@ -23,7 +23,7 @@ public class DefaultParamsManager {
             return new JSONObject();
         }
         try {
-            return new JSONObject(String.join("\n", Files.readAllLines(file.toPath())));
+            return new JSONObject(Files.readString(file.toPath()));
         } catch (IOException e) {
             return new JSONObject();
         }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibAlias.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibAlias.java
@@ -30,8 +30,7 @@ public class LibAlias {
 
         aliases.clear();
         try {
-            List<String> lines = Files.readAllLines(Paths.get("alias.json"));
-            JSONObject obj = new JSONObject(String.join("\n", lines));
+            JSONObject obj = new JSONObject(Files.readString(Paths.get("alias.json")));
 
             for (Iterator<String> it = obj.keys(); it.hasNext(); ) {
                 String key = it.next();

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibIgnore.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibIgnore.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.List;
 
 public class LibIgnore {
     public static void fetchMap() {
@@ -28,8 +27,7 @@ public class LibIgnore {
         LibValue.ignoreEquals.clear();
 
         try {
-            List<String> lines = Files.readAllLines(Paths.get("ignore.json"));
-            JSONObject obj = new JSONObject(String.join("\n", lines));
+            JSONObject obj = new JSONObject(Files.readString(Paths.get("ignore.json")));
 
             for (int i = 0; i < obj.getJSONArray("contain").length(); i++) {
                 LibValue.ignoreContains.add(obj.getJSONArray("contain").getString(i));

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibJson.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibJson.java
@@ -5,7 +5,6 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -59,8 +58,7 @@ public class LibJson {
         if (!Files.exists(path)) {
             return object;
         }
-        String json = String.join("\n", Files.readAllLines(path, Charset.defaultCharset()));
-        return new JSONObject(json);
+        return new JSONObject(Files.readString(path));
     }
 
     /**

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTitle.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTitle.java
@@ -116,7 +116,12 @@ public class LibTitle {
             );
         }
         // 名前変えて、設定ファイルにも記述
-        channel.getManager().setName(name).queue();
+        try {
+            channel.getManager().setName(name).complete();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
         saveSetting(
             titleSetting.put(
                 channel.getId(),

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/MultipleServer.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/MultipleServer.java
@@ -163,7 +163,7 @@ public class MultipleServer {
             return new JSONObject();
         }
         try {
-            return new JSONObject(String.join("\n", Files.readAllLines(file.toPath())));
+            return new JSONObject(Files.readString(file.toPath()));
         } catch (IOException e) {
             return new JSONObject();
         }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VisionAPI.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VisionAPI.java
@@ -36,7 +36,7 @@ public class VisionAPI {
             File file = new File("vision-api-translate.json");
             JSONObject obj = new JSONObject();
             if (file.exists()) {
-                obj = new JSONObject(String.join("\n", Files.readAllLines(file.toPath())));
+                obj = new JSONObject(Files.readString(file.toPath()));
             }
             if (!obj.has(englishDesc)) {
                 obj.put(englishDesc, "");
@@ -158,13 +158,13 @@ public class VisionAPI {
     }
 
     private int getRequestCount() throws IOException {
-        JSONObject obj = new JSONObject(String.join("\n", Files.readAllLines(file.toPath())));
+        JSONObject obj = new JSONObject(Files.readString(file.toPath()));
         return obj.optInt(new SimpleDateFormat("yyyy/MM").format(new Date()), 0);
     }
 
     private void requested() throws IOException {
         String date = new SimpleDateFormat("yyyy/MM").format(new Date());
-        JSONObject obj = new JSONObject(String.join("\n", Files.readAllLines(file.toPath())));
+        JSONObject obj = new JSONObject(Files.readString(file.toPath()));
         int i = obj.optInt(date, 0) + 2;
         obj.put(date, i);
         Files.write(file.toPath(), Collections.singleton(obj.toString()));
@@ -176,7 +176,7 @@ public class VisionAPI {
         if (!file.exists()) {
             return null;
         }
-        JSONArray array = new JSONArray(String.join("\n", Files.readAllLines(file.toPath())));
+        JSONArray array = new JSONArray(Files.readString(file.toPath()));
         List<Result> results = new LinkedList<>();
         for (int i = 0; i < array.length(); i++) {
             JSONObject result = array.getJSONObject(i);

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -416,15 +416,7 @@ public class VoiceText {
 
     @Override
     public String toString() {
-        return """
-            VoiceText{
-            speaker=%s
-            , speed=%s
-            , emotion=%s
-            , emotionLevel=%s
-            , pitch=%s
-            }
-            """.formatted(speaker,speed,emotion,emotionLevel,pitch);
+        return "VoiceText{speaker=%s, speed=%s, emotion=%s, emotionLevel=%s, pitch=%s}".formatted(speaker, speed, emotion, emotionLevel, pitch);
     }
 
     public enum Speaker {


### PR DESCRIPTION
close #94 

- 元タイトル: `🧀CheeseFactory`
- 実行コマンド: `/title test`
- 反映タイトル: `🧀test`
- (絵文字が実行タイトル内にある場合は元タイトルを引き継がない…はず)

`🍅test` って入れてるのに画像のようになってしまうので絵文字を入れた場合の動作が検証できてません

![](https://i.imgur.com/oXwCEGV.png)