### PR TITLE
feat: #101 ツイートのリンクが張られたときにスクリーンネームとツイート内容を読み上げるように

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,5 +146,11 @@
             <version>[1.0,)</version>
             <artifactId>rollbar-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.htmlparser.jericho</groupId>
+            <artifactId>jericho-html</artifactId>
+            <version>3.4</version>
+        </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
close #101 

`https://twitter.com/book000/status/1457387013691244553` -> `Tomachiのツイート「タスク消化祭り」へのリンク`