### PR TITLE
fix: エラー処理を修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         </dependency>
         <dependency>
             <groupId>com.rollbar</groupId>
-            <version>1.7.10</version>
+            <version>1.8.0</version>
             <artifactId>rollbar-java</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/com/jaoafa/jdavcspeaker/Main.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Main.java
@@ -56,7 +56,7 @@ public class Main extends ListenerAdapter {
     static final String prefix = "/";
     static VCSpeakerArgs args;
 
-    public static void main(String[] _args) throws IOException {
+    public static void main(String[] _args) {
         args = new VCSpeakerArgs();
         CmdLineParser parser = new CmdLineParser(args);
         try {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Main.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Main.java
@@ -149,7 +149,6 @@ public class Main extends ListenerAdapter {
 
                 TextChannel channel = LibValue.jda.getTextChannelById(921841152355864586L);
                 if (channel != null) {
-                    System.out.println("if(LibValue.errorReportChannel != null){");
                     StringWriter sw = new StringWriter();
                     PrintWriter pw = new PrintWriter(sw);
                     e.printStackTrace(pw);


### PR DESCRIPTION
https://github.com/jaoafa/JDA-VCSpeaker/pull/122#issuecomment-997234348 の修正

- Rollbarへのエラー送信が動作しない (途中まで動いていたのに動かなくなった)
- 取り合えず依存関係であるRollbarライブラリのアップデート実施、とはいえ相変わらず動かず
- `Thread.setDefaultUncaughtExceptionHandler` がもとの処理を完全上書きするということを忘れていて、標準エラー出力へのスタックトレースが出ない不具合を修正
- エラー時に #jda-vcspeaker-error に投げる
