### PR TITLE
fix: titleコマンドによる変更を直接APIをたたいて変更するように

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
@@ -72,11 +72,11 @@ public class Cmd_Title implements CmdSubstrate {
         if (!libTitle.existsTitle(targetVC)) {
             isInitialized = libTitle.saveAsOriginal(targetVC);
         }
-        boolean bool = libTitle.setTitle(member.getVoiceState().getChannel(), new_title);
-        if (!bool) {
+        LibTitle.ChannelTitleChangeResponse result = libTitle.setTitle(member.getVoiceState().getChannel(), new_title);
+        if (!result.result()) {
             event.replyEmbeds(new EmbedBuilder()
                 .setTitle(":x: 保存に失敗しました。")
-                .setDescription("何らかのエラーが発生したため、VC名の変更に失敗しました。")
+                .setDescription("エラーが発生: `%s`".formatted(result.message()))
                 .setColor(LibEmbedColor.error)
                 .build()
             ).queue();

--- a/src/main/java/com/jaoafa/jdavcspeaker/Main.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Main.java
@@ -52,6 +52,7 @@ public class Main extends ListenerAdapter {
     static VisionAPI visionAPI = null;
     static LibTitle libTitle = null;
     static String speakToken = null;
+    static String discordToken = null;
     static final String prefix = "/";
     static VCSpeakerArgs args;
 
@@ -175,7 +176,8 @@ public class Main extends ListenerAdapter {
         //Task: Token,JDA設定
         speakToken = tokenConfig.getString("Speaker");
 
-        JDABuilder builder = JDABuilder.createDefault(tokenConfig.getString("Discord"))
+        discordToken = tokenConfig.getString("Discord");
+        JDABuilder builder = JDABuilder.createDefault(discordToken)
             //JDASettings
             .setChunkingFilter(ChunkingFilter.ALL)
             .setMemberCachePolicy(MemberCachePolicy.ALL)
@@ -397,6 +399,11 @@ public class Main extends ListenerAdapter {
     @Nullable
     public static VisionAPI getVisionAPI() {
         return visionAPI;
+    }
+
+    @Nullable
+    public static String getDiscordToken() {
+        return discordToken;
     }
 
     public static String getPrefix() {


### PR DESCRIPTION
- チャンネル名の変更は10分に2回までの内部レートリミットが存在する
- JDAからAPI叩くとJDA側のRateLimiterのせいで動作が止まるので、直接生で叩くように変更
- title変更失敗した理由を返すように