### PR TITLE
feat: 他サーバのVCに移動した場合にそれも通知するようにしてみる

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
@@ -1,16 +1,25 @@
 package com.jaoafa.jdavcspeaker.Event;
 
-import com.jaoafa.jdavcspeaker.Lib.LibTitle;
-import com.jaoafa.jdavcspeaker.Lib.MsgFormatter;
-import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
-import com.jaoafa.jdavcspeaker.Lib.VoiceText;
+import com.jaoafa.jdavcspeaker.Lib.*;
 import com.jaoafa.jdavcspeaker.Main;
 import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import net.dv8tion.jda.api.entities.AudioChannel;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * When someone leaves the VC, notify the VC text channel.
@@ -34,22 +43,78 @@ public class Event_Disconnect extends ListenerAdapter {
         User user = event.getMember().getUser();
         AudioChannel channel = event.getChannelLeft();
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;
-        MultipleServer
+
+        String defaultContent = ":outbox_tray: `%s` が <#%s> から退出しました。".formatted(
+            user.getName(),
+            channel.getId());
+        Message message = MultipleServer
             .getVCChannel(event.getGuild())
-            .sendMessage(":outbox_tray: `%s` が <#%s> から退出しました。".formatted(
-                user.getName(),
-                channel.getId()))
-            .queue(
-                message -> {
-                    if (!event.getMember().getUser().isBot())
-                        new VoiceText().play(
-                            TrackInfo.SpeakFromType.QUITED_VC,
-                            message,
-                            "%sが%sから退出しました。".formatted(
-                                user.getName(),
-                                MsgFormatter.formatChannelName(channel))
-                        );
-                }
+            .sendMessage("%s移動先を探しています…。".formatted(defaultContent))
+            .complete();
+
+        if (!event.getMember().getUser().isBot()) {
+            new VoiceText().play(
+                TrackInfo.SpeakFromType.QUITED_VC,
+                message,
+                "%sが%sから退出しました。".formatted(
+                    user.getName(),
+                    MsgFormatter.formatChannelName(channel.getName()))
             );
+        }
+
+        try {
+            JSONArray destinationChannels = getDestinationChannels(user.getId());
+            System.out.println(destinationChannels);
+            if (destinationChannels != null && destinationChannels.length() > 0) {
+                JSONObject destinationChannel = destinationChannels.getJSONObject(0);
+                message.editMessage(":outbox_tray: `%s` が <#%s> から退出し、%s の %s に移動しました。".formatted(
+                    user.getName(),
+                    channel.getId(),
+                    destinationChannel.getString("guildName"),
+                    destinationChannel.getString("channelName"))).queue();
+
+                if (!event.getMember().getUser().isBot()) {
+                    new VoiceText().play(
+                        TrackInfo.SpeakFromType.QUITED_VC,
+                        message,
+                        "%sは%sの%sへ移動しました。".formatted(
+                            user.getName(),
+                            destinationChannel.getString("guildName"),
+                            MsgFormatter.formatChannelName(destinationChannel.getString("channelName")))
+                    );
+                }
+            } else {
+                message.editMessage(defaultContent).queue();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private JSONArray getDestinationChannels(String userId) throws IOException {
+        Process p;
+        try {
+            ProcessBuilder builder = new ProcessBuilder();
+            builder.command(List.of("node", LibFiles.VFile.EXTERNAL_SCRIPT_DESTINATION_CHANNEL.getPath().toString(), "--userId", userId));
+            builder.redirectErrorStream(true);
+            builder.directory(new File("."));
+            p = builder.start();
+            boolean bool = p.waitFor(3, TimeUnit.MINUTES);
+            if (!bool) {
+                return null;
+            }
+            InputStreamReader inputStreamReader = new InputStreamReader(p.getInputStream());
+            Stream<String> streamOfString = new BufferedReader(inputStreamReader).lines();
+            String streamToString = streamOfString.collect(Collectors.joining("\n"));
+            if (p.exitValue() != 0) {
+                System.out.println(p.exitValue());
+                System.out.println(streamToString);
+                return null;
+            }
+            return new JSONArray(streamToString);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
@@ -37,7 +37,7 @@ public class Event_Join extends ListenerAdapter {
                                 message,
                                 "%sが%sに参加しました。".formatted(
                                     user.getName(),
-                                    MsgFormatter.formatChannelName(channel))
+                                    MsgFormatter.formatChannelName(channel.getName()))
                             );
                 }
             );

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
@@ -46,8 +46,8 @@ public class Event_Move extends ListenerAdapter {
                             message,
                             "%sが%sから%sに移動しました。".formatted(
                                 user.getName(),
-                                MsgFormatter.formatChannelName(oldChannel),
-                                MsgFormatter.formatChannelName(newChannel))
+                                MsgFormatter.formatChannelName(oldChannel.getName()),
+                                MsgFormatter.formatChannelName(newChannel.getName()))
                         );
                 }
             );

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibFiles.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibFiles.java
@@ -41,7 +41,8 @@ public class LibFiles {
         TITLE("settings", "title.json"),
         VISION_API("settings", "vision-api.json"),
         VISION_API_WHEN("settings", "vision-api-when.json"),
-        VISION_API_TRANSLATE("settings", "vision-api-translate.json");
+        VISION_API_TRANSLATE("settings", "vision-api-translate.json"),
+        EXTERNAL_SCRIPT_DESTINATION_CHANNEL("external_scripts", "destination-channel.js");
 
         private final Path path;
 

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
@@ -1,7 +1,6 @@
 package com.jaoafa.jdavcspeaker.Lib;
 
 import com.vdurmont.emoji.EmojiParser;
-import net.dv8tion.jda.api.entities.AudioChannel;
 
 import java.util.Arrays;
 import java.util.regex.Matcher;
@@ -54,8 +53,7 @@ public class MsgFormatter {
         return text;
     }
 
-    public static String formatChannelName(AudioChannel channel) {
-        String channelName = channel.getName();
+    public static String formatChannelName(String channelName) {
         channelName = EmojiParser.removeAllEmojis(channelName); // 絵文字の削除
         channelName = parenthesesPattern.matcher(channelName).replaceAll(""); // かっこの削除
         return channelName;


### PR DESCRIPTION
ユーザーがVCから抜けた場合、

1. チャット: `📤 TomachiBot が 🧀CheeseFactory(WorkingSpace) から退出しました。移動先を探しています…。`
2. 読み上げ: `TomachiBotがCheeseFactoryから退出しました。`
3. 移動先を検索
   - 見つかった場合
     1. チャット編集: `📤 TomachiBot が 🧀CheeseFactory(WorkingSpace) から退出し、Tomachi Discord の General に移動しました。`
     2. 読み上げ: `TomachiBotはTomachi DiscordのGeneralに移動しました。`
   - 見つからなかった場合
     1. チャット編集: `📤 TomachiBot が 🧀CheeseFactory(WorkingSpace) から退出しました。`