### PR TITLE
refactor: メッセージ処理のリファクタリングなど

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.idea/libraries
 /.idea/*.xml
 /.idea/.gitignore
+/.idea/shelf
 
 *.iml
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,12 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-alpha.11</version>
+            <version>5.0.0-alpha.12</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20210307</version>
+            <version>20220320</version>
         </dependency>
         <dependency>
             <groupId>com.sedmelluq</groupId>

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Ignore.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Ignore.java
@@ -4,7 +4,6 @@ import com.jaoafa.jdavcspeaker.Framework.Command.CmdDetail;
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdSubstrate;
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
 import com.jaoafa.jdavcspeaker.Lib.LibIgnore;
-import com.jaoafa.jdavcspeaker.Lib.LibValue;
 import com.jaoafa.jdavcspeaker.Main;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
@@ -124,9 +123,9 @@ public class Cmd_Ignore implements CmdSubstrate {
 
         String list;
         if (type.equals("contain")) {
-            list = String.join("\n", LibValue.ignoreContains);
+            list = String.join("\n", LibIgnore.contains);
         } else if (type.equals("equal")) {
-            list = String.join("\n", LibValue.ignoreEquals);
+            list = String.join("\n", LibIgnore.equals);
         } else {
             event.replyEmbeds(new EmbedBuilder()
                 .setTitle(":x: 指定された type が正しくありません")

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Summon.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Summon.java
@@ -27,7 +27,6 @@ public class Cmd_Summon implements CmdSubstrate {
         summon(guild, member, event);
     }
 
-
     void summon(Guild guild, Member member, SlashCommandInteractionEvent event) {
         if (member == null || member.getVoiceState() == null) {
             event.replyEmbeds(new EmbedBuilder()

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Textimg.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Textimg.java
@@ -50,8 +50,8 @@ public class Cmd_Textimg implements CmdSubstrate {
             return;
         }
         String url = Main.getExistsOption(event, "messagelink").getAsString();
-        Pattern msgUrlPattern = Pattern.compile("^https://discord\\.com/channels/([0-9]+)/([0-9]+)/([0-9]+)$");
-        Pattern mediaUrlPattern = Pattern.compile("^https://cdn\\.discordapp\\.com/attachments/([0-9]+)/([0-9]+)/(.+)$");
+        Pattern msgUrlPattern = Pattern.compile("^https://discord(?:app)?\\.com/channels/(\\d+)/(\\d+)/(\\d+)$");
+        Pattern mediaUrlPattern = Pattern.compile("^https://cdn\\.discordapp\\.com/attachments/(\\d+)/(\\d+)/(.+)$");
 
         String imageUrl;
         Matcher msgUrlMatcher = msgUrlPattern.matcher(url);

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
@@ -1,41 +1,20 @@
 package com.jaoafa.jdavcspeaker.Event;
 
 import com.jaoafa.jdavcspeaker.Lib.*;
-import com.jaoafa.jdavcspeaker.Main;
-import com.jaoafa.jdavcspeaker.Player.TrackInfo;
+import com.jaoafa.jdavcspeaker.MessageProcessor.BaseProcessor;
+import com.jaoafa.jdavcspeaker.MessageProcessor.ProcessorType;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.htmlparser.jericho.Source;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.json.JSONObject;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Event_SpeakVCText extends ListenerAdapter {
-    final Pattern urlPattern = Pattern.compile("https?://\\S+", Pattern.CASE_INSENSITIVE);
-    final Pattern messageUrlPattern = Pattern.compile("^https://.*?discord(?:app)?\\.com/channels/([0-9]+)/([0-9]+)/([0-9]+)\\??(.*)$", Pattern.CASE_INSENSITIVE);
-    final Pattern eventDirectLinkUrlPattern = Pattern.compile("^(?:https?://)?(?:www\\.)?discord(?:app)?\\.com/events/([0-9]+)/([0-9]+)$", Pattern.CASE_INSENSITIVE);
-    final Pattern eventInviteLinkUrlPattern = Pattern.compile("^(?:https?://)?(?:www\\.)?(?:discord(?:app)?\\.com/invite|discord\\.gg)/(\\w+)\\?event=([0-9]+)$", Pattern.CASE_INSENSITIVE);
-    final Pattern inviteLinkUrlPattern = Pattern.compile("^(?:https?://)?(?:www\\.)?(?:discord(?:app)?\\.com/invite|discord\\.gg)/(\\w+)$", Pattern.CASE_INSENSITIVE);
-    final Pattern tweetUrlPattern = Pattern.compile("^https://twitter\\.com/(\\w){1,15}/status/([0-9]+)\\??(.*)$", Pattern.CASE_INSENSITIVE);
-    final Pattern titlePattern = Pattern.compile("<title>([^<]+)</title>", Pattern.CASE_INSENSITIVE);
-    final Pattern spoilerPattern = Pattern.compile("\\|\\|.+\\|\\|");
-    final Pattern channelReplyPattern = Pattern.compile("<#([0-9]+)>");
-
     @Override
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
         if (!event.isFromType(ChannelType.TEXT)) {
@@ -56,17 +35,14 @@ public class Event_SpeakVCText extends ListenerAdapter {
             return;
         }
 
-        User user = member.getUser();
-        if (user.isBot()) {
+        User user = event.getAuthor();
+        if (user.getIdLong() == jda.getSelfUser().getIdLong()) {
             return;
         }
 
         final String content = message.getContentDisplay(); // チャンネル名・リプライとかが表示通りになっている文字列が返る
         if (content.equals(".")) {
             return; // .のみは除外
-        }
-        if (content.startsWith("!")) {
-            return; // !から始まるコマンドと思われる文字列を除外
         }
 
         if (guild.getSelfMember().getVoiceState() == null ||
@@ -90,440 +66,48 @@ public class Event_SpeakVCText extends ListenerAdapter {
             }
         }
 
-        // ignore
-        boolean ignoreEquals = LibValue.ignoreEquals.contains(content);
-        boolean ignoreContain = LibValue.ignoreContains.stream().anyMatch(content::contains);
-
-        if (ignoreEquals || ignoreContain) return;
-
-        // 読み上げるメッセージの構築
-        String speakContent = content;
-
-        // Replace discord invite(include event) url
-        speakContent = replacerDiscordInviteLink(jda, guild, speakContent);
-        // Replace url
-        speakContent = replacerLink(jda, speakContent);
-        // Spoiler
-        speakContent = replacerSpoiler(speakContent);
-        // Thread reply
-        speakContent = replacerChannelThreadLink(jda, speakContent);
-        // Emphasize
-        boolean isEmphasize = isEmphasizeMessage(speakContent);
-        if (isEmphasize) {
-            speakContent = replacerEmphasizeMessage(speakContent);
-        }
-
-        UserVoiceTextResult uvtr = getUserVoiceText(user);
+        UserVoiceTextResult uvtr = UserVoiceTextResult.getUserVoiceText(user);
         if (uvtr.isReset()) {
             message.reply("デフォルトパラメーターが不正であるため、リセットしました。").queue();
         }
-        VoiceText vt = isEmphasize ? changeEmphasizeSpeed(uvtr.getVoiceText()) : uvtr.getVoiceText();
-        vt.play(TrackInfo.SpeakFromType.RECEIVED_MESSAGE, message, speakContent);
 
-        for (MessageSticker sticker : message.getStickers()) {
-            vt.play(TrackInfo.SpeakFromType.RECEIVED_MESSAGE, message, "スタンプ「" + sticker.getName() + "」が送信されました。");
-        }
-
-        // 画像等
-        VisionAPI visionAPI = Main.getVisionAPI();
-        if (visionAPI == null) {
-            message.getAttachments()
-                .forEach(attachment -> vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "ファイル「" + attachment.getFileName() + "」が送信されました。"));
-            return;
-        }
-        LibFiles.VDirectory.VISION_API_TEMP.mkdirs();
-        for (Message.Attachment attachment : message.getAttachments()) {
-            if (attachment.isSpoiler()) {
-                vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "スポイラーファイルが送信されました。");
-                return;
-            }
-            attachment
-                .downloadToFile(LibFiles.VDirectory.VISION_API_TEMP.getPath().resolve(attachment.getFileName()).toString())
-                .thenAcceptAsync(file -> {
-                    try {
-                        List<VisionAPI.Result> results = visionAPI.getImageLabelOrText(file);
-                        boolean bool = file.delete();
-                        LibFlow flow = new LibFlow("SpeakVCText.VisionAPI");
-                        if (bool) {
-                            flow.success("Temp attachment file have been delete successfully");
-                        } else {
-                            flow.success("Temp attachment file have been delete failed");
-                        }
-                        if (results == null) {
-                            vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "ファイル「%s」が送信されました。".formatted(attachment.getFileName()));
-                            return;
-                        }
-
-                        List<VisionAPI.Result> sortedResults = results.stream()
-                            .sorted(Comparator.comparing(VisionAPI.Result::getScore, Comparator.reverseOrder()))
-                            .toList();
-                        String text = sortedResults.stream()
-                            .filter(r -> r.getType() == VisionAPI.ResultType.TEXT_DETECTION)
-                            .map(VisionAPI.Result::getDescription)
-                            .findFirst()
-                            .orElse(null);
-
-                        if (text != null) {
-                            vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「%sを含む画像」が送信されました。".formatted(text.length() > 30 ? text.substring(0, 30) : text));
-
-                            message.reply("```\n" + text.replaceAll("\n", " ") + "\n```").queue();
-                        } else {
-                            vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「%s」が送信されました。".formatted(attachment.getFileName()));
-                        }
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                });
-        }
-    }
-
-    /**
-     * チャンネルIDをもとに、チャンネルまたはスレッドを取得します<br>
-     * VCSpeakerが参加しているテキストチャンネルとスレッドに対応しますが、アーカイブされているスレッドには対応していません。
-     *
-     * @param jda       JDA
-     * @param channelId チャンネルID (or スレッドID)
-     *
-     * @return チャンネル、見つからなければnull
-     */
-    GuildMessageChannel getChannelOrThread(JDA jda, String channelId) {
-        TextChannel textChannel = jda.getTextChannelById(channelId);
-        if (textChannel != null) {
-            return textChannel;
-        }
-        return jda.getThreadChannelById(channelId);
-    }
-
-    /**
-     * チャンネルIDをもとに、テキスト/ボイスチャンネルまたはスレッドを取得します<br>
-     * VCSpeakerが参加しているテキスト/ボイスチャンネルとスレッドに対応しますが、アーカイブされているスレッドには対応していません。
-     *
-     * @param jda       JDA
-     * @param channelId チャンネルID (or スレッドID)
-     *
-     * @return チャンネル、見つからなければnull
-     */
-    Channel getTextVoiceChannelOrThread(JDA jda, String channelId) {
-        TextChannel textChannel = jda.getTextChannelById(channelId);
-        if (textChannel != null) {
-            return textChannel;
-        }
-        VoiceChannel voiceChannel = jda.getVoiceChannelById(channelId);
-        if (voiceChannel != null) {
-            return voiceChannel;
-        }
-        return jda.getThreadChannelById(channelId);
-    }
-
-    String replacerLink(JDA jda, String content) {
-        Matcher m = urlPattern.matcher(content);
-        while (m.find()) {
-            String url = m.group();
-
-            // Discordメッセージリンク
-            Matcher msgUrlMatcher = messageUrlPattern.matcher(url);
-            if (msgUrlMatcher.find()) {
-                String channelId = msgUrlMatcher.group(2);
-                String messageId = msgUrlMatcher.group(3);
-
-                GuildMessageChannel channel = getChannelOrThread(jda, channelId);
-                if (channel == null) continue;
-                Message message = channel.retrieveMessageById(messageId).complete();
-                if (message == null) continue;
-
-                channel = message.getGuildChannel();
-                String channelName = "チャンネル「" + channel.getName() + "」";
-                if (channel instanceof ThreadChannel) {
-                    channelName = "チャンネル「" + ((ThreadChannel) channel).getParentChannel().getName() + "」のスレッド「" + channel.getName() + "」";
-                }
-
-                content = content.replace(url, "%sが%sで送信したメッセージのリンク".formatted(
-                    message.getAuthor().getAsTag(),
-                    channelName
-                ));
+        List<ProcessorType> processorTypes = ProcessorType.getMatchProcessor(message);
+        for (BaseProcessor processor : getMessageProcessors()) {
+            if (!processorTypes.contains(processor.getType())) {
                 continue;
             }
 
-            Matcher tweetUrlMatcher = tweetUrlPattern.matcher(url);
-            if (tweetUrlMatcher.find()) {
-                String screenName = tweetUrlMatcher.group(1);
-                String tweetId = tweetUrlMatcher.group(2);
+            processor.execute(
+                jda,
+                guild,
+                channel,
+                member,
+                message,
+                uvtr
+            );
+        }
+    }
 
-                Tweet tweet = getTweet(screenName, tweetId);
-                if (tweet != null) {
-                    System.out.println(tweet);
-                    content = content.replace(url, "%sのツイート「%s」へのリンク".formatted(
-                        EmojiWrapper.removeAllEmojis(tweet.authorName()),
-                        tweet.plainText()
-                    ));
+    List<BaseProcessor> getMessageProcessors() {
+        List<BaseProcessor> list = new ArrayList<>();
+        try {
+            for (Class<?> eventClass : new LibClassFinder().findClasses("com.jaoafa.jdavcspeaker.MessageProcessor")) {
+                if (eventClass.isInterface() ||
+                    !eventClass.getSimpleName().endsWith("Processor")
+                    || eventClass.getEnclosingClass() != null
+                    || eventClass.getName().contains("$")) {
                     continue;
                 }
-            }
-
-            // GIFリンク
-            if (url.endsWith(".gif")) {
-                content = content.replace(url, "GIF画像へのリンク");
-                continue;
-            }
-
-            // Webページのタイトル取得
-            String title = getTitle(url);
-            if (title != null) {
-                System.out.println("title: " + title);
-                if (title.length() >= 30) {
-                    title = title.substring(0, 30) + "以下略";
+                Object instance = ((Constructor<?>) eventClass.getConstructor()).newInstance();
+                if (!(instance instanceof BaseProcessor)) {
+                    continue;
                 }
-                System.out.println("title 2: " + title);
-                content = content.replace(url, "Webページ「%s」へのリンク".formatted(title));
-            } else {
-                content = content.replace(url, "Webページへのリンク");
+
+                list.add((BaseProcessor) eventClass.getConstructor().newInstance());
             }
+        } catch (Exception e) {
+            new LibReporter(null, e);
         }
-        return content;
-    }
-
-    String replacerChannelThreadLink(JDA jda, String content) {
-        return channelReplyPattern.matcher(content).replaceAll(result -> {
-            String channelId = result.group(1);
-            Channel channel = getTextVoiceChannelOrThread(jda, channelId);
-            if (channel == null) return "どこかのチャンネルへのリンク";
-            String channelName = "チャンネル「" + channel.getName() + "」へのリンク";
-            if (channel instanceof ThreadChannel) {
-                channelName = "チャンネル「" + ((ThreadChannel) channel).getParentChannel().getName() + "」のスレッド「" + channel.getName() + "」へのリンク";
-            }
-            return channelName;
-        });
-    }
-
-    String replacerDiscordInviteLink(JDA jda, Guild sendFromGuild, String content) {
-        content = eventDirectLinkUrlPattern.matcher(content).replaceAll(result -> {
-            String guildId = result.group(1);
-            String eventId = result.group(2);
-
-            Guild guild = jda.getGuildById(guildId);
-            if (guild == null) return "どこかのサーバのイベントへのリンク";
-
-            String eventName = getScheduledEventName(guildId, eventId);
-            if (eventName == null) return "サーバ「" + guild.getName() + "」のイベントへのリンク";
-
-            if (guild.getIdLong() == sendFromGuild.getIdLong()) {
-                return "イベント「" + eventName + "」へのリンク";
-            }
-            return "サーバ「" + guild.getName() + "」のイベント「" + eventName + "」へのリンク";
-        });
-
-        content = eventInviteLinkUrlPattern.matcher(content).replaceAll(result -> {
-            String inviteCode = result.group(1);
-            String eventId = result.group(2);
-
-            DiscordInvite invite = getInvite(inviteCode, eventId);
-            if (invite == null) return "どこかのサーバのイベントへのリンク";
-            if (invite.eventName() == null) return "サーバ「" + invite.guildName() + "」のイベントへのリンク";
-
-            if (invite.guildId().equals(sendFromGuild.getId())) {
-                return "イベント「" + invite.eventName() + "」へのリンク";
-            }
-            return "サーバ「" + invite.guildName() + "」のイベント「" + invite.eventName() + "」へのリンク";
-        });
-
-        content = inviteLinkUrlPattern.matcher(content).replaceAll(result -> {
-            String inviteCode = result.group(1);
-
-            DiscordInvite invite = getInvite(inviteCode, null);
-            if (invite == null) return "どこかのサーバへの招待リンク";
-            if (invite.channelName() == null) return "サーバ「" + invite.guildName() + "」への招待リンク";
-
-            if (invite.guildId().equals(sendFromGuild.getId())) {
-                return "チャンネル「" + invite.channelName() + "」への招待リンク";
-            }
-            return "サーバ「" + invite.guildName() + "」のチャンネル「" + invite.channelName() + "」への招待リンク";
-        });
-
-        return content;
-    }
-
-    String replacerSpoiler(String content) {
-        return spoilerPattern.matcher(content).replaceAll(" ピー ");
-    }
-
-    boolean isEmphasizeMessage(String content) {
-        return
-            content.matches("^\\*\\*(.[　 ]){2,}.\\*\\*$") || // **あ い う え お** OR **あ　い　う　え　お**
-                content.matches("^(.[　 ]){2,}.$") || // あ い う え お OR あ　い　う　え　お
-                content.matches("^\\*\\*(.+)\\*\\*$"); // **あああああああ**
-    }
-
-    String replacerEmphasizeMessage(String content) {
-        for (String s : Arrays.asList("**", " ", "　")) {
-            content = content.replace(s, "");
-        }
-        return content;
-    }
-
-    VoiceText changeEmphasizeSpeed(VoiceText vt) {
-        try {
-            return vt.setSpeed(Math.max(vt.getSpeed() / 2, 50));
-        } catch (VoiceText.WrongSpeedException e) {
-            return vt;
-        }
-    }
-
-    @Nullable
-    String getTitle(String url) {
-        try {
-            OkHttpClient client = new OkHttpClient().newBuilder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(10, TimeUnit.SECONDS)
-                .build();
-            Request request = new Request.Builder().url(url).build();
-            try (Response response = client.newCall(request).execute()) {
-                if (response.code() != 200 && response.code() != 302) {
-                    return null;
-                }
-                ResponseBody body = response.body();
-                if (body == null) {
-                    return null;
-                }
-                Matcher m = titlePattern.matcher(body.string());
-                return m.find() ? m.group(1) : null;
-            }
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    record Tweet(String authorName, String html, String plainText) {
-    }
-
-    @Nullable
-    Tweet getTweet(String screenName, String tweetId) {
-        String url = "https://publish.twitter.com/oembed?url=https://twitter.com/%s/status/%s".formatted(screenName, tweetId);
-        try {
-            OkHttpClient client = new OkHttpClient().newBuilder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(10, TimeUnit.SECONDS)
-                .build();
-            Request request = new Request.Builder().url(url).build();
-            try (Response response = client.newCall(request).execute()) {
-                if (response.code() != 200 && response.code() != 302) {
-                    return null;
-                }
-                ResponseBody body = response.body();
-                if (body == null) {
-                    return null;
-                }
-                JSONObject json = new JSONObject(body.string());
-                String html = json.getString("html");
-                String authorName = json.getString("author_name");
-                String plainText = new Source(html.replaceAll("<a.*>(.*)</a>", ""))
-                    .getFirstElement("p")
-                    .getRenderer()
-                    .setMaxLineLength(Integer.MAX_VALUE)
-                    .setNewLine(null)
-                    .toString();
-                System.out.println(plainText);
-                return new Tweet(authorName, html, plainText);
-            }
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    @Nullable
-    String getScheduledEventName(String guildId, String eventId) {
-        String url = "https://discord.com/api/guilds/%s/scheduled-events/%s".formatted(guildId, eventId);
-        try {
-            OkHttpClient client = new OkHttpClient().newBuilder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(10, TimeUnit.SECONDS)
-                .build();
-            Request request = new Request.Builder()
-                .url(url)
-                .header("Authorization", "Bot " + Main.getDiscordToken())
-                .build();
-            try (Response response = client.newCall(request).execute()) {
-                if (response.code() != 200 && response.code() != 302) {
-                    return null;
-                }
-                ResponseBody body = response.body();
-                if (body == null) {
-                    return null;
-                }
-                JSONObject json = new JSONObject(body.string());
-                return json.getString("name");
-            }
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    record DiscordInvite(
-        String code,
-        String guildId,
-        String guildName,
-        String channelId,
-        String channelName,
-        @Nullable String inviterId,
-        @Nullable String inviterName,
-        @Nullable String inviterDiscriminator,
-        @Nullable String eventName,
-        @Nullable String eventId
-    ) {
-    }
-
-    @Nullable
-    DiscordInvite getInvite(String inviteCode, String eventId) {
-        String url = "https://discord.com/api/invites/%s".formatted(inviteCode);
-        if (eventId != null) {
-            url += "?guild_scheduled_event_id=%s".formatted(eventId);
-        }
-        try {
-            OkHttpClient client = new OkHttpClient().newBuilder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(10, TimeUnit.SECONDS)
-                .build();
-            Request request = new Request.Builder()
-                .url(url)
-                .build();
-            try (Response response = client.newCall(request).execute()) {
-                if (response.code() != 200 && response.code() != 302) {
-                    return null;
-                }
-                ResponseBody body = response.body();
-                if (body == null) {
-                    return null;
-                }
-                JSONObject json = new JSONObject(body.string());
-                return new DiscordInvite(
-                    json.getString("code"),
-                    json.getJSONObject("guild").getString("id"),
-                    json.getJSONObject("guild").getString("name"),
-                    json.getJSONObject("channel").getString("id"),
-                    json.getJSONObject("channel").getString("name"),
-                    json.has("inviter") ? json.getJSONObject("inviter").getString("id") : null,
-                    json.has("inviter") ? json.getJSONObject("inviter").getString("username") : null,
-                    json.has("inviter") ? json.getJSONObject("inviter").getString("discriminator") : null,
-                    json.has("guild_scheduled_event") ? json.getJSONObject("guild_scheduled_event").getString("name") : null,
-                    json.has("guild_scheduled_event") ? json.getJSONObject("guild_scheduled_event").getString("id") : null
-                );
-            }
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    UserVoiceTextResult getUserVoiceText(User user) {
-        try {
-            return new UserVoiceTextResult(new VoiceText(user), false);
-        } catch (VoiceText.WrongException e) {
-            new DefaultParamsManager(user).setDefaultVoiceText(null);
-            return new UserVoiceTextResult(new VoiceText(), true);
-        }
-    }
-
-    record UserVoiceTextResult(VoiceText vt, boolean isReset) {
-        public VoiceText getVoiceText() {
-            return vt;
-        }
+        return list;
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/EmojiWrapper.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/EmojiWrapper.java
@@ -6,6 +6,7 @@ import com.vdurmont.emoji.EmojiParser;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Objects;
 
 public class EmojiWrapper {
     /**
@@ -17,7 +18,7 @@ public class EmojiWrapper {
      */
     public static @NotNull String parseToAliases(@NotNull String input) {
         List<String> rawEmojis = EmojiParser.extractEmojis(input);
-        for (Emoji emoji : rawEmojis.stream().map(EmojiManager::getByUnicode).toList()) {
+        for (Emoji emoji : rawEmojis.stream().map(EmojiManager::getByUnicode).filter(Objects::nonNull).toList()) {
             String alias = ":" + emoji.getAliases().get(0) + ":";
             input = input.replaceAll(emoji.getUnicode(), alias);
             input = input.replaceAll(emoji.getTrimmedUnicode(), alias);
@@ -34,7 +35,7 @@ public class EmojiWrapper {
      */
     public static @NotNull String removeAllEmojis(@NotNull String input) {
         List<String> rawEmojis = EmojiParser.extractEmojis(input);
-        for (Emoji emoji : rawEmojis.stream().map(EmojiManager::getByUnicode).toList()) {
+        for (Emoji emoji : rawEmojis.stream().map(EmojiManager::getByUnicode).filter(Objects::nonNull).toList()) {
             input = input.replaceAll(emoji.getUnicode(), "");
             input = input.replaceAll(emoji.getTrimmedUnicode(), "");
         }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibIgnore.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibIgnore.java
@@ -2,8 +2,13 @@ package com.jaoafa.jdavcspeaker.Lib;
 
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class LibIgnore {
     private static final LibFiles.VFile vFile = LibFiles.VFile.IGNORE;
+    public static final List<String> contains = new ArrayList<>();
+    public static final List<String> equals = new ArrayList<>();
 
     public static void fetchMap() {
         LibFlow ignoreFlow = new LibFlow("LibIgnore");
@@ -17,8 +22,8 @@ public class LibIgnore {
             }
         }
 
-        LibValue.ignoreContains.clear();
-        LibValue.ignoreEquals.clear();
+        contains.clear();
+        equals.clear();
 
         JSONObject obj = vFile.readJSONObject();
         if (obj == null) {
@@ -27,38 +32,45 @@ public class LibIgnore {
         }
 
         for (int i = 0; i < obj.getJSONArray("contain").length(); i++) {
-            LibValue.ignoreContains.add(obj.getJSONArray("contain").getString(i));
+            contains.add(obj.getJSONArray("contain").getString(i));
         }
         for (int i = 0; i < obj.getJSONArray("equal").length(); i++) {
-            LibValue.ignoreEquals.add(obj.getJSONArray("equal").getString(i));
+            equals.add(obj.getJSONArray("equal").getString(i));
         }
-        ignoreFlow.success("除外設定をロードしました（含む: %d / 一致: %d）。".formatted(LibValue.ignoreContains.size(), LibValue.ignoreEquals.size()));
+        ignoreFlow.success("除外設定をロードしました（含む: %d / 一致: %d）。".formatted(contains.size(), equals.size()));
     }
 
     public static void saveJson() {
         JSONObject obj = new JSONObject();
-        obj.put("contain", LibValue.ignoreContains);
-        obj.put("equal", LibValue.ignoreEquals);
+        obj.put("contain", contains);
+        obj.put("equal", equals);
         vFile.write(obj);
     }
 
     public static void addToContainIgnore(String value) {
-        LibValue.ignoreContains.add(value);
+        contains.add(value);
         saveJson();
     }
 
     public static void addToEqualIgnore(String value) {
-        LibValue.ignoreEquals.add(value);
+        equals.add(value);
         saveJson();
     }
 
     public static void removeToContainIgnore(String value) {
-        LibValue.ignoreContains.remove(value);
+        contains.remove(value);
         saveJson();
     }
 
     public static void removeToEqualIgnore(String value) {
-        LibValue.ignoreEquals.remove(value);
+        equals.remove(value);
         saveJson();
+    }
+
+    public static boolean isIgnoreMessage(String content) {
+        boolean isEquals = equals.contains(content);
+        boolean isContain = contains.stream().anyMatch(content::contains);
+
+        return isEquals || isContain;
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibValue.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibValue.java
@@ -3,12 +3,7 @@ package com.jaoafa.jdavcspeaker.Lib;
 import com.rollbar.notifier.Rollbar;
 import net.dv8tion.jda.api.JDA;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class LibValue {
-    public static final List<String> ignoreContains = new ArrayList<>();
-    public static final List<String> ignoreEquals = new ArrayList<>();
     public static JDA jda;
     public static Rollbar rollbar = null;
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/MsgFormatter.java
@@ -13,7 +13,7 @@ public class MsgFormatter {
         text = EmojiWrapper.parseToAliases(text);
 
         // ReplaceCustomEmoji
-        String regex = "<a?:(.+?):([0-9]+)>";
+        String regex = "<a?:(.+?):(\\d+)>";
         Pattern p = Pattern.compile(regex);
         Matcher m = p.matcher(text);
         while (m.find()) {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/UserVoiceTextResult.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/UserVoiceTextResult.java
@@ -1,0 +1,18 @@
+package com.jaoafa.jdavcspeaker.Lib;
+
+import net.dv8tion.jda.api.entities.User;
+
+public record UserVoiceTextResult(VoiceText vt, boolean isReset) {
+    public VoiceText getVoiceText() {
+        return vt;
+    }
+
+    public static UserVoiceTextResult getUserVoiceText(User user) {
+        try {
+            return new UserVoiceTextResult(new VoiceText(user), false);
+        } catch (VoiceText.WrongException e) {
+            new DefaultParamsManager(user).setDefaultVoiceText(null);
+            return new UserVoiceTextResult(new VoiceText(), true);
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VisionAPI.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VisionAPI.java
@@ -187,10 +187,11 @@ public class VisionAPI {
     }
 
     public void saveCache(String hash, List<Result> results, JSONObject raw_object) throws IOException {
-        Path file = LibFiles.VDirectory.VISION_API_CACHES.resolve(Path.of(hash));
+        Path hashFileName = Path.of(hash);
+        Path file = LibFiles.VDirectory.VISION_API_CACHES.resolve(hashFileName);
         LibFiles.VDirectory.VISION_API_CACHES.mkdirs();
 
-        Path file_result = LibFiles.VDirectory.VISION_API_RESULTS.resolve(Path.of(hash));
+        Path file_result = LibFiles.VDirectory.VISION_API_RESULTS.resolve(hashFileName);
         LibFiles.VDirectory.VISION_API_RESULTS.mkdirs();
 
         JSONArray array = new JSONArray();
@@ -215,7 +216,17 @@ public class VisionAPI {
         );
     }
 
-    public boolean isCheckTarget(File file) {
+    public static List<String> getSupportedFileExtensions() {
+        return List.of(
+            "jpg",
+            "jpeg",
+            "png",
+            "gif",
+            "bmp"
+        );
+    }
+
+    public static boolean isCheckTarget(File file) {
         try {
             String mime = getMimeType(file);
             return getSupportedContentType().contains(mime);
@@ -224,7 +235,11 @@ public class VisionAPI {
         }
     }
 
-    public String getMimeType(File file) throws IOException {
+    public static boolean isCheckTarget(String extension) {
+        return getSupportedFileExtensions().contains(extension);
+    }
+
+    public static String getMimeType(File file) throws IOException {
         InputStream is = new BufferedInputStream(new FileInputStream(file));
         return URLConnection.guessContentTypeFromStream(is);
     }

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/AttachmentsProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/AttachmentsProcessor.java
@@ -1,0 +1,110 @@
+package com.jaoafa.jdavcspeaker.MessageProcessor;
+
+import com.jaoafa.jdavcspeaker.Lib.*;
+import com.jaoafa.jdavcspeaker.Main;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 添付ファイルのメッセージプロセッサ
+ * <p>
+ * ・拡張子で画像系ファイルであれば画像として扱う
+ * 　・その後、MimeTypeでも判定する
+ * ・拡張子で画像系ファイルでなければファイルとして扱う。この際はファイル名を読み上げる
+ */
+public class AttachmentsProcessor implements BaseProcessor {
+    @Override
+    public ProcessorType getType() {
+        return ProcessorType.ATTACHMENTS;
+    }
+
+    @Override
+    public void execute(JDA jda, Guild guild, TextChannel channel, Member member, Message message, UserVoiceTextResult uvtr) {
+        for (Message.Attachment attachment : message.getAttachments()) {
+            // スポイラーファイルは無条件でスポイラーファイルとして読み上げ
+            if (attachment.isSpoiler()) {
+                uvtr.vt().play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "スポイラーファイルが送信されました。");
+                return;
+            }
+
+            // 画像か、それ以外で分岐する
+            if (VisionAPI.isCheckTarget(attachment.getFileExtension())) {
+                processImage(message, uvtr.vt(), attachment);
+                return;
+            }
+
+            processFile(message, uvtr.vt(), attachment);
+        }
+    }
+
+    void processImage(Message message, VoiceText vt, Message.Attachment attachment) {
+        VisionAPI visionAPI = Main.getVisionAPI();
+        if (visionAPI == null) {
+            processFile(message, vt, attachment);
+            return;
+        }
+        LibFiles.VDirectory.VISION_API_TEMP.mkdirs();
+        attachment
+            .getProxy()
+            .downloadToFile(LibFiles.VDirectory.VISION_API_TEMP.getPath().resolve(attachment.getFileName()).toFile())
+            .thenAcceptAsync(file -> {
+                try {
+                    List<VisionAPI.Result> results = visionAPI.getImageLabelOrText(file);
+                    boolean bool = file.delete();
+                    LibFlow flow = new LibFlow("SpeakVCText.VisionAPI");
+                    if (bool) {
+                        flow.success("Temp attachment file have been delete successfully");
+                    } else {
+                        flow.success("Temp attachment file have been delete failed");
+                    }
+                    if (results == null) {
+                        processFile(message, vt, attachment);
+                        return;
+                    }
+
+                    List<VisionAPI.Result> sortedResults = results.stream()
+                        .sorted(Comparator.comparing(VisionAPI.Result::getScore, Comparator.reverseOrder()))
+                        .toList();
+                    String text = sortedResults.stream()
+                        .filter(r -> r.getType() == VisionAPI.ResultType.TEXT_DETECTION)
+                        .map(VisionAPI.Result::getDescription)
+                        .findFirst()
+                        .orElse(null);
+
+                    if (text != null) {
+                        vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「%sを含む画像」が送信されました。".formatted(text.length() > 30 ? text.substring(0, 30) : text));
+
+                        message
+                            .getChannel()
+                            .sendMessage("```\n" + safeSubstring(text.replaceAll("\n", " ")) + "\n```")
+                            .reference(message)
+                            .mentionRepliedUser(false)
+                            .queue();
+                    } else {
+                        vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「%s」が送信されました。".formatted(attachment.getFileName()));
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+    }
+
+    void processFile(Message message, VoiceText vt, Message.Attachment attachment) {
+        vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "ファイル「%s」が送信されました。".formatted(attachment.getFileName()));
+    }
+
+    String safeSubstring(String str) {
+        if (str.length() <= 1500) {
+            return str;
+        }
+        return str.substring(0, 1500 - 1);
+    }
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/BaseProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/BaseProcessor.java
@@ -1,0 +1,16 @@
+package com.jaoafa.jdavcspeaker.MessageProcessor;
+
+import com.jaoafa.jdavcspeaker.Lib.UserVoiceTextResult;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+public interface BaseProcessor {
+    /** プロセッサの種別 */
+    ProcessorType getType();
+
+    /** 処理関数 */
+    void execute(JDA jda, Guild guild, TextChannel channel, Member member, Message message, UserVoiceTextResult uvtr);
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/CreatedThreadProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/CreatedThreadProcessor.java
@@ -1,0 +1,30 @@
+package com.jaoafa.jdavcspeaker.MessageProcessor;
+
+import com.jaoafa.jdavcspeaker.Lib.UserVoiceTextResult;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+/**
+ * スレッド作成メッセージプロセッサ
+ * <p>
+ * ・スレッド作成時に自動投稿されるスレッド作成メッセージを処理する。
+ */
+public class CreatedThreadProcessor implements BaseProcessor {
+    @Override
+    public ProcessorType getType() {
+        return ProcessorType.CREATED_THREAD;
+    }
+
+    @Override
+    public void execute(JDA jda, Guild guild, TextChannel channel, Member member, Message message, UserVoiceTextResult uvtr) {
+        // 特定のメッセージからの派生としてスレッドを作成する場合は本プロセッサは動作しない可能性がある
+
+        String threadName = message.getContentRaw(); // message.getStartedThread() が必ず null になるので、暫定的にこれで代用
+
+        uvtr.vt().play(TrackInfo.SpeakFromType.CREATED_THREAD, message, "%sがスレッド「%s」を開始しました。".formatted(member.getUser().getName(), threadName));
+    }
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/DefaultMessageProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/DefaultMessageProcessor.java
@@ -1,0 +1,412 @@
+package com.jaoafa.jdavcspeaker.MessageProcessor;
+
+import com.jaoafa.jdavcspeaker.Lib.EmojiWrapper;
+import com.jaoafa.jdavcspeaker.Lib.LibIgnore;
+import com.jaoafa.jdavcspeaker.Lib.UserVoiceTextResult;
+import com.jaoafa.jdavcspeaker.Lib.VoiceText;
+import com.jaoafa.jdavcspeaker.Main;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.*;
+import net.htmlparser.jericho.Source;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 「ユーザーが送信したデフォルトメッセージ」のメッセージプロセッサ
+ * <p>
+ * ・メッセージ本文自体を原則そのまま読み上げる。（エイリアス等は適用する）
+ * ・画像など添付ファイルは ProcessorType.ATTACHMENTS で処理する。
+ */
+public class DefaultMessageProcessor implements BaseProcessor {
+    final Pattern urlPattern = Pattern.compile("https?://\\S+", Pattern.CASE_INSENSITIVE);
+    final Pattern messageUrlPattern = Pattern.compile("^https://.*?discord(?:app)?\\.com/channels/(\\d+)/(\\d+)/(\\d+)\\??(.*)$", Pattern.CASE_INSENSITIVE);
+    final Pattern eventDirectLinkUrlPattern = Pattern.compile("^(?:https?://)?(?:www\\.)?discord(?:app)?\\.com/events/(\\d+)/(\\d+)$", Pattern.CASE_INSENSITIVE);
+    final Pattern eventInviteLinkUrlPattern = Pattern.compile("^(?:https?://)?(?:www\\.)?(?:discord(?:app)?\\.com/invite|discord\\.gg)/(\\w+)\\?event=(\\d+)$", Pattern.CASE_INSENSITIVE);
+    final Pattern inviteLinkUrlPattern = Pattern.compile("^(?:https?://)?(?:www\\.)?(?:discord(?:app)?\\.com/invite|discord\\.gg)/(\\w+)$", Pattern.CASE_INSENSITIVE);
+    final Pattern tweetUrlPattern = Pattern.compile("^https://twitter\\.com/(\\w){1,15}/status/(\\d+)\\??(.*)$", Pattern.CASE_INSENSITIVE);
+    final Pattern titlePattern = Pattern.compile("<title>([^<]+)</title>", Pattern.CASE_INSENSITIVE);
+    final Pattern spoilerPattern = Pattern.compile("\\|\\|.+\\|\\|");
+    final Pattern channelReplyPattern = Pattern.compile("<#(\\d+)>");
+
+    @Override
+    public ProcessorType getType() {
+        return ProcessorType.DEFAULT;
+    }
+
+    @Override
+    public void execute(JDA jda, Guild guild, TextChannel channel, Member member, Message message, UserVoiceTextResult uvtr) {
+        String speakContent = message.getContentDisplay();
+
+        if (LibIgnore.isIgnoreMessage(speakContent)) {
+            return;
+        }
+
+        // Replace discord invite(include event) url
+        speakContent = replacerDiscordInviteLink(jda, guild, speakContent);
+        // Replace url
+        speakContent = replacerLink(jda, speakContent);
+        // Spoiler
+        speakContent = replacerSpoiler(speakContent);
+        // Thread reply
+        speakContent = replacerChannelThreadLink(jda, speakContent);
+        // Emphasize
+        boolean isEmphasize = isEmphasizeMessage(speakContent);
+        if (isEmphasize) {
+            speakContent = replacerEmphasizeMessage(speakContent);
+        }
+
+        VoiceText vt = isEmphasize ? changeEmphasizeSpeed(uvtr.getVoiceText()) : uvtr.getVoiceText();
+        vt.play(
+            TrackInfo.SpeakFromType.RECEIVED_MESSAGE,
+            message,
+            speakContent
+        );
+    }
+
+    /**
+     * チャンネルIDをもとに、チャンネルまたはスレッドを取得します<br>
+     * VCSpeakerが参加しているテキストチャンネルとスレッドに対応しますが、アーカイブされているスレッドには対応していません。
+     *
+     * @param jda       JDA
+     * @param channelId チャンネルID (or スレッドID)
+     *
+     * @return チャンネル、見つからなければnull
+     */
+    MessageChannel getChannelOrThread(JDA jda, String channelId) {
+        TextChannel textChannel = jda.getTextChannelById(channelId);
+        if (textChannel != null) {
+            return textChannel;
+        }
+        return jda.getThreadChannelById(channelId);
+    }
+
+    /**
+     * チャンネルIDをもとに、テキスト/ボイスチャンネルまたはスレッドを取得します<br>
+     * VCSpeakerが参加しているテキスト/ボイスチャンネルとスレッドに対応しますが、アーカイブされているスレッドには対応していません。
+     *
+     * @param jda       JDA
+     * @param channelId チャンネルID (or スレッドID)
+     *
+     * @return チャンネル、見つからなければnull
+     */
+    Channel getTextVoiceChannelOrThread(JDA jda, String channelId) {
+        TextChannel textChannel = jda.getTextChannelById(channelId);
+        if (textChannel != null) {
+            return textChannel;
+        }
+        VoiceChannel voiceChannel = jda.getVoiceChannelById(channelId);
+        if (voiceChannel != null) {
+            return voiceChannel;
+        }
+        return jda.getThreadChannelById(channelId);
+    }
+
+    String replacerLink(JDA jda, String content) {
+        Matcher m = urlPattern.matcher(content);
+        while (m.find()) {
+            String url = m.group();
+
+            // Discordメッセージリンク
+            Matcher msgUrlMatcher = messageUrlPattern.matcher(url);
+            if (msgUrlMatcher.find()) {
+                String channelId = msgUrlMatcher.group(2);
+                String messageId = msgUrlMatcher.group(3);
+
+                MessageChannel channel = getChannelOrThread(jda, channelId);
+                if (channel == null) continue;
+                Message message = channel.retrieveMessageById(messageId).complete();
+                if (message == null) continue;
+
+                channel = message.getChannel();
+                String channelName = "チャンネル「" + channel.getName() + "」";
+                if (channel instanceof ThreadChannel) {
+                    channelName = "チャンネル「%s」のスレッド「%s」".formatted(((ThreadChannel) channel).getParentChannel().getName(), channel.getName());
+                }
+
+                content = content.replace(url, "%sが%sで送信したメッセージのリンク".formatted(
+                    message.getAuthor().getAsTag(),
+                    channelName
+                ));
+                continue;
+            }
+
+            Matcher tweetUrlMatcher = tweetUrlPattern.matcher(url);
+            if (tweetUrlMatcher.find()) {
+                String screenName = tweetUrlMatcher.group(1);
+                String tweetId = tweetUrlMatcher.group(2);
+
+                Tweet tweet = getTweet(screenName, tweetId);
+                if (tweet != null) {
+                    System.out.println(tweet);
+                    content = content.replace(url, "%sのツイート「%s」へのリンク".formatted(
+                        EmojiWrapper.removeAllEmojis(tweet.authorName()),
+                        tweet.plainText()
+                    ));
+                    continue;
+                }
+            }
+
+            // GIFリンク
+            if (url.endsWith(".gif")) {
+                content = content.replace(url, "GIF画像へのリンク");
+                continue;
+            }
+
+            // Webページのタイトル取得
+            String title = getTitle(url);
+            if (title != null) {
+                System.out.println("title: " + title);
+                if (title.length() >= 30) {
+                    title = title.substring(0, 30) + "以下略";
+                }
+                System.out.println("title 2: " + title);
+                content = content.replace(url, "Webページ「%s」へのリンク".formatted(title));
+            } else {
+                content = content.replace(url, "Webページへのリンク");
+            }
+        }
+        return content;
+    }
+
+    String replacerChannelThreadLink(JDA jda, String content) {
+        return channelReplyPattern.matcher(content).replaceAll(result -> {
+            String channelId = result.group(1);
+            Channel channel = getTextVoiceChannelOrThread(jda, channelId);
+            if (channel == null) return "どこかのチャンネルへのリンク";
+            String channelName = "チャンネル「" + channel.getName() + "」へのリンク";
+            if (channel instanceof ThreadChannel) {
+                channelName = "チャンネル「%s」のスレッド「%s」へのリンク".formatted(((ThreadChannel) channel).getParentChannel().getName(), channel.getName());
+            }
+            return channelName;
+        });
+    }
+
+    String replacerDiscordInviteLink(JDA jda, Guild sendFromGuild, String content) {
+        content = eventDirectLinkUrlPattern.matcher(content).replaceAll(result -> {
+            String guildId = result.group(1);
+            String eventId = result.group(2);
+
+            Guild guild = jda.getGuildById(guildId);
+            if (guild == null) return "どこかのサーバのイベントへのリンク";
+
+            String eventName = getScheduledEventName(guildId, eventId);
+            if (eventName == null) return "サーバ「%s」のイベントへのリンク".formatted(guild.getName());
+
+            if (guild.getIdLong() == sendFromGuild.getIdLong()) {
+                return "イベント「%s」へのリンク".formatted(eventName);
+            }
+            return "サーバ「%s」のイベント「%s」へのリンク".formatted(guild.getName(), eventName);
+        });
+
+        content = eventInviteLinkUrlPattern.matcher(content).replaceAll(result -> {
+            String inviteCode = result.group(1);
+            String eventId = result.group(2);
+
+            DiscordInvite invite = getInvite(inviteCode, eventId);
+            if (invite == null) return "どこかのサーバのイベントへのリンク";
+            if (invite.eventName() == null) return "サーバ「%s」のイベントへのリンク".formatted(invite.guildName());
+
+            if (invite.guildId().equals(sendFromGuild.getId())) {
+                return "イベント「%s」へのリンク".formatted(invite.eventName());
+            }
+            return "サーバ「%s」のイベント「%s」へのリンク".formatted(invite.guildName(), invite.eventName());
+        });
+
+        content = inviteLinkUrlPattern.matcher(content).replaceAll(result -> {
+            String inviteCode = result.group(1);
+
+            DiscordInvite invite = getInvite(inviteCode, null);
+            if (invite == null) return "どこかのサーバへの招待リンク";
+            if (invite.channelName() == null) return "サーバ「%s」への招待リンク".formatted(invite.guildName());
+
+            if (invite.guildId().equals(sendFromGuild.getId())) {
+                return "チャンネル「%s」への招待リンク".formatted(invite.channelName());
+            }
+            return "サーバ「%s」のチャンネル「%s」への招待リンク".formatted(invite.guildName(), invite.channelName());
+        });
+
+        return content;
+    }
+
+    String replacerSpoiler(String content) {
+        return spoilerPattern.matcher(content).replaceAll(" ピー ");
+    }
+
+    boolean isEmphasizeMessage(String content) {
+        return
+            content.matches("^\\*\\*(.[　 ]){2,}.\\*\\*$") || // **あ い う え お** OR **あ　い　う　え　お**
+                content.matches("^(.[　 ]){2,}.$") || // あ い う え お OR あ　い　う　え　お
+                content.matches("^\\*\\*(.+)\\*\\*$"); // **あああああああ**
+    }
+
+    String replacerEmphasizeMessage(String content) {
+        for (String s : Arrays.asList("**", " ", "　")) {
+            content = content.replace(s, "");
+        }
+        return content;
+    }
+
+    VoiceText changeEmphasizeSpeed(VoiceText vt) {
+        try {
+            return vt.setSpeed(Math.max(vt.getSpeed() / 2, 50));
+        } catch (VoiceText.WrongSpeedException e) {
+            return vt;
+        }
+    }
+
+    @Nullable
+    String getTitle(String url) {
+        try {
+            OkHttpClient client = new OkHttpClient().newBuilder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build();
+            Request request = new Request.Builder().url(url).build();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.code() != 200 && response.code() != 302) {
+                    return null;
+                }
+                ResponseBody body = response.body();
+                if (body == null) {
+                    return null;
+                }
+                Matcher m = titlePattern.matcher(body.string());
+                return m.find() ? m.group(1) : null;
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    record Tweet(String authorName, String html, String plainText) {
+    }
+
+    @Nullable
+    Tweet getTweet(String screenName, String tweetId) {
+        String url = "https://publish.twitter.com/oembed?url=https://twitter.com/%s/status/%s".formatted(screenName, tweetId);
+        try {
+            OkHttpClient client = new OkHttpClient().newBuilder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build();
+            Request request = new Request.Builder().url(url).build();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.code() != 200 && response.code() != 302) {
+                    return null;
+                }
+                ResponseBody body = response.body();
+                if (body == null) {
+                    return null;
+                }
+                JSONObject json = new JSONObject(body.string());
+                String html = json.getString("html");
+                String authorName = json.getString("author_name");
+                String plainText = new Source(html.replaceAll("<a.*>(.*)</a>", ""))
+                    .getFirstElement("p")
+                    .getRenderer()
+                    .setMaxLineLength(Integer.MAX_VALUE)
+                    .setNewLine(null)
+                    .toString();
+                System.out.println(plainText);
+                return new Tweet(authorName, html, plainText);
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    String getScheduledEventName(String guildId, String eventId) {
+        String url = "https://discord.com/api/guilds/%s/scheduled-events/%s".formatted(guildId, eventId);
+        try {
+            OkHttpClient client = new OkHttpClient().newBuilder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build();
+            Request request = new Request.Builder()
+                .url(url)
+                .header("Authorization", "Bot " + Main.getDiscordToken())
+                .build();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.code() != 200 && response.code() != 302) {
+                    return null;
+                }
+                ResponseBody body = response.body();
+                if (body == null) {
+                    return null;
+                }
+                JSONObject json = new JSONObject(body.string());
+                return json.getString("name");
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    record DiscordInvite(
+        String code,
+        String guildId,
+        String guildName,
+        String channelId,
+        String channelName,
+        @Nullable String inviterId,
+        @Nullable String inviterName,
+        @Nullable String inviterDiscriminator,
+        @Nullable String eventName,
+        @Nullable String eventId
+    ) {
+    }
+
+    @Nullable
+    DiscordInvite getInvite(String inviteCode, String eventId) {
+        String url = "https://discord.com/api/invites/%s".formatted(inviteCode);
+        if (eventId != null) {
+            url += "?guild_scheduled_event_id=%s".formatted(eventId);
+        }
+        try {
+            OkHttpClient client = new OkHttpClient().newBuilder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build();
+            Request request = new Request.Builder()
+                .url(url)
+                .build();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.code() != 200 && response.code() != 302) {
+                    return null;
+                }
+                ResponseBody body = response.body();
+                if (body == null) {
+                    return null;
+                }
+                JSONObject json = new JSONObject(body.string());
+                return new DiscordInvite(
+                    json.getString("code"),
+                    json.getJSONObject("guild").getString("id"),
+                    json.getJSONObject("guild").getString("name"),
+                    json.getJSONObject("channel").getString("id"),
+                    json.getJSONObject("channel").getString("name"),
+                    json.has("inviter") ? json.getJSONObject("inviter").getString("id") : null,
+                    json.has("inviter") ? json.getJSONObject("inviter").getString("username") : null,
+                    json.has("inviter") ? json.getJSONObject("inviter").getString("discriminator") : null,
+                    json.has("guild_scheduled_event") ? json.getJSONObject("guild_scheduled_event").getString("name") : null,
+                    json.has("guild_scheduled_event") ? json.getJSONObject("guild_scheduled_event").getString("id") : null
+                );
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/ProcessorType.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/ProcessorType.java
@@ -1,0 +1,51 @@
+package com.jaoafa.jdavcspeaker.MessageProcessor;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageType;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public enum ProcessorType {
+    /** ユーザーが送信したデフォルトメッセージ */
+    DEFAULT((message) -> message.getType() == MessageType.DEFAULT && !message.getAuthor().isBot() && !message.getType().isSystem()),
+    /** Bot が送信したデフォルトメッセージ */
+    BOT_DEFAULT((message) -> message.getType() == MessageType.DEFAULT && message.getAuthor().isBot() && !message.getType().isSystem()),
+    /** ユーザーがメッセージに対して返信したメッセージ (Embed メッセージを含む) */
+    REPLY((message) -> message.getType() == MessageType.INLINE_REPLY && !message.getAuthor().isBot() && !message.getType().isSystem()),
+    /** Bot がメッセージに対して返信したメッセージ (Embed メッセージを含む) */
+    BOT_REPLY((message) -> message.getType() == MessageType.INLINE_REPLY && message.getAuthor().isBot() && !message.getType().isSystem()),
+    /** Bot に対してのコマンドと思われるメッセージ */
+    BOT_COMMAND((message) -> message.getType() == MessageType.DEFAULT && getBotCommandPrefix(message.getContentDisplay()) && !message.getType().isSystem()),
+    /** ユーザーが送信したEmbedメッセージ */
+    EMBED((message) -> message.getType() == MessageType.DEFAULT && message.getEmbeds().size() > 0 && !message.getAuthor().isBot() && !message.getType().isSystem()),
+    /** Bot が送信したEmbedメッセージ */
+    BOT_EMBED((message) -> message.getType() == MessageType.DEFAULT && message.getEmbeds().size() > 0 && message.getAuthor().isBot() && !message.getType().isSystem()),
+    /** スタンプ (Sticker) メッセージ */
+    STICKERS((message) -> message.getType() == MessageType.DEFAULT && message.getStickers().size() > 0 && !message.getType().isSystem()),
+    /** 添付ファイル (メッセージ) */
+    ATTACHMENTS((message) -> message.getType() == MessageType.DEFAULT && message.getAttachments().size() > 0 && !message.getType().isSystem()),
+    /** スレッド開始通知メッセージ (メッセージ派生かどうかを問わない) */
+    CREATED_THREAD((message) -> message.getType() == MessageType.THREAD_CREATED),
+    /** スラッシュコマンドによるメッセージ */
+    WITH_APPLICATION_COMMAND((message) -> message.getType() == MessageType.SLASH_COMMAND);
+
+    private final Predicate<Message> predicate;
+
+    ProcessorType(Predicate<Message> predicate) {
+        this.predicate = predicate;
+    }
+
+    public boolean check(Message message) {
+        return predicate.test(message);
+    }
+
+    public static List<ProcessorType> getMatchProcessor(Message message) {
+        return Stream.of(values()).filter(p -> p.check(message)).toList();
+    }
+
+    static boolean getBotCommandPrefix(String content) {
+        return Stream.of("/", "!").anyMatch(content::startsWith);
+    }
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/StickersProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/StickersProcessor.java
@@ -1,0 +1,25 @@
+package com.jaoafa.jdavcspeaker.MessageProcessor;
+
+import com.jaoafa.jdavcspeaker.Lib.UserVoiceTextResult;
+import com.jaoafa.jdavcspeaker.Player.TrackInfo;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.*;
+
+/**
+ * スタンプ (Sticker) プロセッサ
+ * <p>
+ * ・「スタンプ XXX が送信されました。」と読み上げる
+ */
+public class StickersProcessor implements BaseProcessor {
+    @Override
+    public ProcessorType getType() {
+        return ProcessorType.STICKERS;
+    }
+
+    @Override
+    public void execute(JDA jda, Guild guild, TextChannel channel, Member member, Message message, UserVoiceTextResult uvtr) {
+        for (MessageSticker sticker : message.getStickers()) {
+            uvtr.vt().play(TrackInfo.SpeakFromType.RECEIVED_STICKER, message, "スタンプ「%s」が送信されました。".formatted(sticker.getName()));
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackInfo.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackInfo.java
@@ -36,6 +36,8 @@ public record TrackInfo(SpeakFromType speakFromType, Message message) {
         RECEIVED_FILE,
         /** 画像が送信された */
         RECEIVED_IMAGE,
+        /** スタンプが送信された */
+        RECEIVED_STICKER,
         /** VCにユーザーが参加した */
         JOINED_VC,
         /** VCでユーザーが移動した */
@@ -47,6 +49,8 @@ public record TrackInfo(SpeakFromType speakFromType, Message message) {
         /** GoLiveを終了した */
         ENDED_GOLIVE,
         /** VCタイトルを変えた */
-        CHANGED_TITLE
+        CHANGED_TITLE,
+        /** スレッドを作成した */
+        CREATED_THREAD
     }
 }


### PR DESCRIPTION
なんかちょこちょこいじったりしてたら色々混ざったプルリクになっちゃいました。申し訳ないです。

- 「メッセージ」と一言に言っても「ユーザから送られたメッセージ」・「Botから送られたメッセージ」・「ユーザが送ったシステムメッセージ」など様々なメッセージ形態があります。
  - このようなさまざまな形態のメッセージに対応するため、「メッセージプロセッサ (MessageProcessor)」パッケージを生やしました。
  - 現時点で、「ユーザーが送信したデフォルトメッセージ」・「スタンプ (Sticker) メッセージ」・「添付ファイル (メッセージ)」・「スレッド開始通知メッセージ (メッセージ派生かどうかを問わない)」に対応しています。
- TrackInfo.SpeakFromType に `RECEIVED_STICKER`, `CREATED_THREAD` を追加
- 画像内のテキストがあまりにも多い場合に2000文字を超えてしまいメッセージが送信できない不具合を修正。本文は1500文字で切り上げるように
- ignore 系の変数を LibValue から LibIgnore に移動
- IntelliJのインスペクション適用
  - `Lib/EmojiWrapper` にて、 `EmojiManager::getByUnicode` が nullable なのにも関わらず適切な Null フィルタリングが行われていない問題の修正
  - 正規表現 `[0-9]` を `\d` に置き換え
- 依存パッケージアップデート
  - JDA: `5.0.0-alpha.11` → `5.0.0-alpha.12`
  - org.json.json: `20210307` → `20220320`

close #163
ref #109