### PR TITLE
fix: ユーザー名やVC名などの前後にスペースを追加

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Title.java
@@ -112,7 +112,7 @@ public class Cmd_Title implements CmdSubstrate {
                 origin_msg -> new VoiceText().play(
                     TrackInfo.SpeakFromType.CHANGED_TITLE,
                     origin_msg,
-                    String.format("タイトルを%sに変更しました", title)
+                    String.format("タイトルを %s に変更しました", title)
                 )
             )
         );

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
@@ -56,7 +56,7 @@ public class Event_Disconnect extends ListenerAdapter {
             new VoiceText().play(
                 TrackInfo.SpeakFromType.QUITED_VC,
                 message,
-                "%sが%sから退出しました。".formatted(
+                "%s が %s から退出しました。".formatted(
                     user.getName(),
                     MsgFormatter.formatChannelName(channel.getName()))
             );
@@ -80,7 +80,7 @@ public class Event_Disconnect extends ListenerAdapter {
                         new VoiceText().play(
                             TrackInfo.SpeakFromType.QUITED_VC,
                             message,
-                            "%sは%sの%sへ移動しました。".formatted(
+                            "%s は %s の %s へ移動しました。".formatted(
                                 user.getName(),
                                 destinationChannel.getString("guildName"),
                                 MsgFormatter.formatChannelName(destinationChannel.getString("channelName")))

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GoLiveNotify.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_GoLiveNotify.java
@@ -41,9 +41,9 @@ public class Event_GoLiveNotify extends ListenerAdapter {
                 channel.getId());
 
         String speakText = isStream ?
-            "%sがGoLiveを開始しました。".formatted(
+            "%s がGoLiveを開始しました。".formatted(
                 member.getUser().getName()) :
-            "%sがGoLiveを終了しました。".formatted(
+            "%s がGoLiveを終了しました。".formatted(
                 member.getUser().getName());
 
         MultipleServer

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Join.java
@@ -35,7 +35,7 @@ public class Event_Join extends ListenerAdapter {
                             .play(
                                 TrackInfo.SpeakFromType.JOINED_VC,
                                 message,
-                                "%sが%sに参加しました。".formatted(
+                                "%s が %s に参加しました。".formatted(
                                     user.getName(),
                                     MsgFormatter.formatChannelName(channel.getName()))
                             );

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Move.java
@@ -44,7 +44,7 @@ public class Event_Move extends ListenerAdapter {
                         new VoiceText().play(
                             TrackInfo.SpeakFromType.MOVED_VC,
                             message,
-                            "%sが%sから%sに移動しました。".formatted(
+                            "%s が %s から %s に移動しました。".formatted(
                                 user.getName(),
                                 MsgFormatter.formatChannelName(oldChannel.getName()),
                                 MsgFormatter.formatChannelName(newChannel.getName()))

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/AttachmentsProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/AttachmentsProcessor.java
@@ -80,7 +80,7 @@ public class AttachmentsProcessor implements BaseProcessor {
                         .orElse(null);
 
                     if (text != null) {
-                        vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「%sを含む画像」が送信されました。".formatted(text.length() > 30 ? text.substring(0, 30) : text));
+                        vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「%s を含む画像」が送信されました。".formatted(text.length() > 30 ? text.substring(0, 30) : text));
 
                         message
                             .getChannel()
@@ -89,7 +89,7 @@ public class AttachmentsProcessor implements BaseProcessor {
                             .mentionRepliedUser(false)
                             .queue();
                     } else {
-                        vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「%s」が送信されました。".formatted(attachment.getFileName()));
+                        vt.play(TrackInfo.SpeakFromType.RECEIVED_IMAGE, message, "画像ファイル「 %s 」が送信されました。".formatted(attachment.getFileName()));
                     }
                 } catch (IOException e) {
                     e.printStackTrace();
@@ -98,7 +98,7 @@ public class AttachmentsProcessor implements BaseProcessor {
     }
 
     void processFile(Message message, VoiceText vt, Message.Attachment attachment) {
-        vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "ファイル「%s」が送信されました。".formatted(attachment.getFileName()));
+        vt.play(TrackInfo.SpeakFromType.RECEIVED_FILE, message, "ファイル「 %s 」が送信されました。".formatted(attachment.getFileName()));
     }
 
     String safeSubstring(String str) {

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/CreatedThreadProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/CreatedThreadProcessor.java
@@ -25,6 +25,6 @@ public class CreatedThreadProcessor implements BaseProcessor {
 
         String threadName = message.getContentRaw(); // message.getStartedThread() が必ず null になるので、暫定的にこれで代用
 
-        uvtr.vt().play(TrackInfo.SpeakFromType.CREATED_THREAD, message, "%sがスレッド「%s」を開始しました。".formatted(member.getUser().getName(), threadName));
+        uvtr.vt().play(TrackInfo.SpeakFromType.CREATED_THREAD, message, "%s がスレッド「 %s 」を開始しました。".formatted(member.getUser().getName(), threadName));
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/StickersProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/StickersProcessor.java
@@ -19,7 +19,7 @@ public class StickersProcessor implements BaseProcessor {
     @Override
     public void execute(JDA jda, Guild guild, TextChannel channel, Member member, Message message, UserVoiceTextResult uvtr) {
         for (MessageSticker sticker : message.getStickers()) {
-            uvtr.vt().play(TrackInfo.SpeakFromType.RECEIVED_STICKER, message, "スタンプ「%s」が送信されました。".formatted(sticker.getName()));
+            uvtr.vt().play(TrackInfo.SpeakFromType.RECEIVED_STICKER, message, "スタンプ「 %s 」が送信されました。".formatted(sticker.getName()));
         }
     }
 }


### PR DESCRIPTION
- close #177 

以下の作業を実施。

- titleコマンド: タイトルの変更時に発言するタイトルの前後にスペースを追加
- 誰かがVCに接続した時: ユーザ名とチャンネル名の前後にスペースを追加
- 誰かがVC移動した時: ユーザ名とチャンネル名の前後にスペースを追加
- 誰かがVCから切断した時: ユーザ名とチャンネル名の前後にスペースを追加
- GoLiveを開始した時: 開始時、ユーザー名の後にスペースを追加
- GoLiveを終了した時: 開始時、ユーザー名の後にスペースを追加
- 誰かが画像を送信した時: 画像テキストの後にスペースを追加
- 誰かがファイルを送信した時: ファイル名の前後にスペースを追加
- 誰かがスレッドを開始した時: ユーザ名とスレッド名の前後にスペースを追加
- 誰かがスタンプを送信した時: スタンプ名の前後にスペースを追加