### PR TITLE
feat(textimg): media.discordapp.netに対応

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Textimg.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Textimg.java
@@ -51,7 +51,7 @@ public class Cmd_Textimg implements CmdSubstrate {
         }
         String url = Main.getExistsOption(event, "messagelink").getAsString();
         Pattern msgUrlPattern = Pattern.compile("^https://discord(?:app)?\\.com/channels/(\\d+)/(\\d+)/(\\d+)$");
-        Pattern mediaUrlPattern = Pattern.compile("^https://cdn\\.discordapp\\.com/attachments/(\\d+)/(\\d+)/(.+)$");
+        Pattern mediaUrlPattern = Pattern.compile("^https://(?:cdn|media)\\.discordapp\\.(?:com|net)/attachments/(\\d+)/(\\d+)/(.+)$");
 
         String imageUrl;
         Matcher msgUrlMatcher = msgUrlPattern.matcher(url);


### PR DESCRIPTION
一部の環境（スマホ/タブレット？）で出てくる `media.discordapp.net` ドメインの画像リンクに対応します。