### PR TITLE
feat: 画像投稿時、同時にtextimgの結果を返すようにする

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Textimg.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Textimg.java
@@ -2,10 +2,7 @@ package com.jaoafa.jdavcspeaker.Command;
 
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdDetail;
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdSubstrate;
-import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
-import com.jaoafa.jdavcspeaker.Lib.LibFlow;
-import com.jaoafa.jdavcspeaker.Lib.MultipleServer;
-import com.jaoafa.jdavcspeaker.Lib.VisionAPI;
+import com.jaoafa.jdavcspeaker.Lib.*;
 import com.jaoafa.jdavcspeaker.Main;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
@@ -14,16 +11,10 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class Cmd_Textimg implements CmdSubstrate {
     @Override
@@ -110,7 +101,7 @@ public class Cmd_Textimg implements CmdSubstrate {
 
         File file;
         try {
-            file = getTempimgPath(imageUrl);
+            file = LibTextImg.getTempimgPath(imageUrl);
         } catch (IOException e) {
             e.printStackTrace();
             event.getHook().editOriginalEmbeds(new EmbedBuilder()
@@ -130,31 +121,5 @@ public class Cmd_Textimg implements CmdSubstrate {
         new LibFlow("textimg").success("File: %s", file.getAbsolutePath());
 
         event.getHook().editOriginal(file, "output.png").queue();
-    }
-
-    private File getTempimgPath(String mediaUrl) throws IOException {
-        File tmp = File.createTempFile("textimg", ".png");
-        Process p;
-        try {
-            ProcessBuilder builder = new ProcessBuilder();
-            builder.command(List.of("php", "external_scripts/image-text.php", mediaUrl, tmp.getAbsolutePath()));
-            builder.redirectErrorStream(true);
-            builder.directory(new File("."));
-            p = builder.start();
-            boolean bool = p.waitFor(3, TimeUnit.MINUTES);
-            if (!bool) {
-                return null;
-            }
-            InputStreamReader inputStreamReader = new InputStreamReader(p.getInputStream());
-            Stream<String> streamOfString = new BufferedReader(inputStreamReader).lines();
-            String streamToString = streamOfString.collect(Collectors.joining("\n"));
-            System.out.println(streamToString);
-            if (p.exitValue() != 0) {
-                return null;
-            }
-        } catch (InterruptedException e) {
-            return null;
-        }
-        return tmp;
     }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTextImg.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/LibTextImg.java
@@ -1,0 +1,38 @@
+package com.jaoafa.jdavcspeaker.Lib;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class LibTextImg {
+    public static File getTempimgPath(String mediaUrl) throws IOException {
+        File tmp = File.createTempFile("textimg", ".png");
+        Process p;
+        try {
+            ProcessBuilder builder = new ProcessBuilder();
+            builder.command(List.of("php", "external_scripts/image-text.php", mediaUrl, tmp.getAbsolutePath()));
+            builder.redirectErrorStream(true);
+            builder.directory(new File("."));
+            p = builder.start();
+            boolean bool = p.waitFor(3, TimeUnit.MINUTES);
+            if (!bool) {
+                return null;
+            }
+            InputStreamReader inputStreamReader = new InputStreamReader(p.getInputStream());
+            Stream<String> streamOfString = new BufferedReader(inputStreamReader).lines();
+            String streamToString = streamOfString.collect(Collectors.joining("\n"));
+            System.out.println(streamToString);
+            if (p.exitValue() != 0) {
+                return null;
+            }
+        } catch (InterruptedException e) {
+            return null;
+        }
+        return tmp;
+    }
+}


### PR DESCRIPTION
- close #185 

画像内テキストの返信時、textimgで出力されるテキスト位置が確認できる加工済み画像を自動添付するようになります。
また返信の形態を通常テキストからEmbedに変更します。

## Screenshots

![image](https://user-images.githubusercontent.com/8929706/203852337-2f730545-3af9-4053-b352-8f1990e5c875.png)
![image](https://user-images.githubusercontent.com/8929706/203852339-dfd9e812-2ca4-4875-b69f-7308a428cc89.png)

画像はこちらからお借りしました: https://twitter.com/nknknk1206/status/1595703786495827970