### PR TITLE
fix: rollbarに報告されるコードバージョンが不適切な問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       ref_dev: "dev"
       files: |
         ./target/jdavcspeaker-jar-with-dependencies.jar
+
     runs-on: ubuntu-latest
+
     steps:
       - name: 👉 Release Version
         id: version
@@ -24,16 +26,19 @@ jobs:
           github_token: ${{ github.token }}
           default_bump: "minor"
           custom_release_rules: "breaking:major:💣 Breaking Changes,feat:minor:✨ Features,fix:patch:💣 Bug Fixes,docs:patch:📰 Docs,chore:patch:🎨 Chore,pref:patch:🎈 Performance improvements,refactor:patch:🧹 Refactoring,build:patch:🔍 Build,ci:patch:🔍 CI,revert:patch:⏪ Revert,style:patch:🧹 Style,test:patch:👀 Test"
+
       - name: 📻 Setup JDK16
         uses: actions/setup-java@v3.0.0
         with:
           distribution: "zulu"
           java-version: ${{ env.jdk }}
+
       - name: 📦 Checkout ${{ github.repository }}
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
           token: ${{ github.token }}
+
       - name: ⌛ Cache
         uses: actions/cache@v2
         with:
@@ -41,11 +46,18 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
+      - name: ✏ Insert Version
+        run: |
+          sed -r -i "1,/version/s#<version>(.+?)</version>#<version>${{ steps.version.outputs.new_version }}</version>#" pom.xml
+          git diff
+
       - name: 📦 Package
         env:
           project_version: ${{ steps.version.outputs.new_version }}
         run: |
           mvn ${{ env.maven_cmd }}
+
       - name: 🗃️ Publish Release (main)
         env:
           project_version: ${{ steps.version.outputs.new_version }}
@@ -55,6 +67,7 @@ jobs:
           generate_release_notes: true
           tag_name: ${{ env.project_version }}
           files: ${{ env.files }}
+
       - name: 🗃️ Publish Release (dev)
         env:
           project_version: ${{ steps.version.outputs.new_version }}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
                     <archive>
                         <manifest>
                             <mainClass>com.jaoafa.jdavcspeaker.Main</mainClass>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
                     </archive>
                 </configuration>

--- a/src/main/java/com/jaoafa/jdavcspeaker/Main.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Main.java
@@ -42,7 +42,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.jar.JarEntry;
@@ -139,7 +138,7 @@ public class Main extends ListenerAdapter {
             LibValue.rollbar = Rollbar.init(ConfigBuilder
                 .withAccessToken(tokenConfig.getString("rollbar"))
                 .environment(getLocalHostName())
-                .codeVersion(getGitHash())
+                .codeVersion(Main.class.getPackage().getImplementationVersion())
                 .handleUncaughtErrors(false)
                 .build());
 
@@ -162,6 +161,7 @@ public class Main extends ListenerAdapter {
                             .addField("Summary", String.format("%s (%s)", e.getMessage(), e.getClass().getName()), false)
                             .addField("Details", details.substring(0, 1000), false)
                             .addField("Thread Name", t.getName(), false)
+                            .setFooter("JDA-VCSpeaker %s".formatted(Main.class.getPackage().getImplementationVersion()))
                             .setColor(Color.RED)
                             .build())
                         .addFile(is, "stacktrace.txt")
@@ -188,6 +188,7 @@ public class Main extends ListenerAdapter {
                             .setTitle("JDA-VCSpeaker Error Reporter")
                             .addField("Summary", String.format("%s (%s)", e.getMessage(), e.getClass().getName()), false)
                             .addField("Details", details.substring(0, 1000), false)
+                            .setFooter("JDA-VCSpeaker %s".formatted(Main.class.getPackage().getImplementationVersion()))
                             .setColor(Color.RED)
                             .build())
                         .addFile(is, "stacktrace.txt")
@@ -305,39 +306,6 @@ public class Main extends ListenerAdapter {
         try {
             return InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
-            return "Unknown";
-        }
-    }
-
-    private static String getGitHash() {
-        try {
-            Process p;
-            try {
-                ProcessBuilder builder = new ProcessBuilder();
-                builder.command("git", "rev-parse", "--short", "HEAD");
-                builder.redirectErrorStream(true);
-                p = builder.start();
-                boolean bool = p.waitFor(10, TimeUnit.SECONDS);
-                if (!bool) {
-                    return null;
-                }
-            } catch (InterruptedException e) {
-                return null;
-            }
-            try (InputStream is = p.getInputStream()) {
-                try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
-                    StringBuilder text = new StringBuilder();
-                    while (true) {
-                        String line = br.readLine();
-                        if (line == null) {
-                            break;
-                        }
-                        text.append(line).append("\n");
-                    }
-                    return text.toString().trim();
-                }
-            }
-        } catch (IOException e) {
             return "Unknown";
         }
     }


### PR DESCRIPTION
従来、git short hash をコードバージョンとして割り当てていましたが、#173 でビルド自体を GitHub Actions で行うようになったことに伴い、ホストサーバ側で git コマンドを叩いても git short hash が取得できなくなりました。
そのため、このプルリクエスト以降 pom.xml の version 値をコードバージョンとして使うように修正し、また関連する処理も修正します。

今回のプルリクエストで変更される点は以下の4つです。

- `Rollbar.init` 時、`codeVersion` として渡される値が `git rev-parse --short HEAD` コマンドの結果ではなく、`Main.class.getPackage().getImplementationVersion()` の返り値に変わります。
- `getImplementationVersion()` を使用するため、`maven-assembly-plugin` の `configuration.archive.manifest` の `addDefaultImplementationEntries` と `addDefaultSpecificationEntries` プロパティを `true` にします。これにより `pom.xml` の `version` プロパティの値が、成果物 jar にある `META-INF/MANIFEST.MF` に `Implementation-Version` へ書き込まれるようになります。
- リリース CI に `✏ Insert Version` の項目を追加。`mathieudutour/github-tag-action` が出力する `steps.version.outputs.new_version` を拾って pom.xml の version プロパティに反映させるようにしました。この箇所は未テストなので、うまく動かなかったら修正 PR を出します
- (見やすさ重視で CI のジョプ毎にスペースを入れました。空改行ないの見づれぇ！)