### PR TITLE
fix: 当該ユーザーにブロックされているためにリアクションをつけられない場合にエラーを出さない

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -333,7 +333,7 @@ public class VoiceText {
 
         message
             .addReaction("\uD83D\uDC40") // :eyes:
-            .queue(null);
+            .queue();
 
         try {
             OkHttpClient client = new OkHttpClient();
@@ -374,7 +374,7 @@ public class VoiceText {
             }
             message
                 .removeReaction("\uD83D\uDC40") // :eyes:
-                .queue(null);
+                .queue();
             filteringQueue(speakFromType, message);
             TrackInfo info = new TrackInfo(speakFromType, message);
             PlayerManager.getINSTANCE().loadAndPlay(info, LibFiles.VDirectory.VOICETEXT_CACHES.resolve(hashFileName).toString());

--- a/src/main/java/com/jaoafa/jdavcspeaker/Main.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Main.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
@@ -173,6 +174,12 @@ public class Main extends ListenerAdapter {
             });
             final Consumer<? super Throwable> prevDefaultFailure = RestActionImpl.getDefaultFailure();
             RestActionImpl.setDefaultFailure((e) -> {
+                if (e instanceof ErrorResponseException ere) {
+                    // 当該ユーザーからブロックされているためにリアクションをつけられない場合、または当該メッセージが存在しない場合は無視
+                    if (ere.getErrorResponse() == ErrorResponse.REACTION_BLOCKED || ere.getErrorResponse() == ErrorResponse.UNKNOWN_MESSAGE) {
+                        return;
+                    }
+                }
                 e.printStackTrace();
                 LibValue.rollbar.critical(e);
 

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
@@ -110,8 +110,8 @@ public class TrackScheduler extends AudioEventAdapter {
             message.addReaction("\uD83D\uDDE3") // :speaking_head:
                 .queue();
         } catch (ErrorResponseException e) {
-            // メッセージが削除されていて見つからないだけだったらスタックトレースを出さない
-            if (e.getErrorResponse() != ErrorResponse.UNKNOWN_MESSAGE) {
+            // メッセージが削除されていて見つからない or ブロックされていてリアクションできないだけだったらスタックトレースを出さない
+            if (e.getErrorResponse() != ErrorResponse.UNKNOWN_MESSAGE && e.getErrorResponse() != ErrorResponse.REACTION_BLOCKED) {
                 e.printStackTrace();
             }
             return false;

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
@@ -9,6 +9,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 
 import java.util.Timer;
 import java.util.TimerTask;
@@ -90,7 +91,7 @@ public class TrackScheduler extends AudioEventAdapter {
         if (channel == null) return;
         channel.retrieveMessageById(info.getMessage().getIdLong())
             .queue(msg -> msg.removeReaction("\uD83D\uDDE3", LibValue.jda.getSelfUser()) // :speaking_head:
-                .queue(null));
+                .queue());
     }
 
     boolean reactionSpeaking(AudioTrack track) {
@@ -107,8 +108,12 @@ public class TrackScheduler extends AudioEventAdapter {
                 return false;
             }
             message.addReaction("\uD83D\uDDE3") // :speaking_head:
-                .queue(null);
+                .queue();
         } catch (ErrorResponseException e) {
+            // メッセージが削除されていて見つからないだけだったらスタックトレースを出さない
+            if (e.getErrorResponse() != ErrorResponse.UNKNOWN_MESSAGE) {
+                e.printStackTrace();
+            }
             return false;
         }
         return true;

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
@@ -9,7 +9,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
-import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.internal.requests.RestActionImpl;
 
 import java.util.Timer;
 import java.util.TimerTask;
@@ -110,10 +110,7 @@ public class TrackScheduler extends AudioEventAdapter {
             message.addReaction("\uD83D\uDDE3") // :speaking_head:
                 .queue();
         } catch (ErrorResponseException e) {
-            // メッセージが削除されていて見つからない or ブロックされていてリアクションできないだけだったらスタックトレースを出さない
-            if (e.getErrorResponse() != ErrorResponse.UNKNOWN_MESSAGE && e.getErrorResponse() != ErrorResponse.REACTION_BLOCKED) {
-                e.printStackTrace();
-            }
+            RestActionImpl.getDefaultFailure().accept(e);
             return false;
         }
         return true;


### PR DESCRIPTION
- close #184 

とあるユーザーがVCSpeakerをブロックしているようで、メッセージに対してリアクションをつけられずエラーが発生していました。このプルリクエストはこの問題の解決をします。
