### PR TITLE
fix: 音声をキュー挿入するかどうかの処理を調整

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
@@ -37,7 +37,7 @@ public class TrackScheduler extends AudioEventAdapter {
      * @param track The track to play or add to queue.
      */
     public void queue(AudioTrack track) {
-        if (player.startTrack(track, true)) {
+        if (this.queue.isEmpty() && player.startTrack(track, true)) {
             // トラックが開始された場合
             reactionSpeaking(track);
         } else {


### PR DESCRIPTION
- #145 

`queue` メソッド呼び出し時、`player.startTrack` の返り値がどうにも信頼できないので `this.queue` が空かどうかを判断するようにします。

ただ、これで #145 が改善されるわけではなく、APIからの音声データダウンロードの順番によって前後する問題があります。特にキャッシュがあるテキストの場合、ダウンロード中のテキストよりも先に読まれる可能性があります。
とはいえ、この改善で「キューが溜まっているのに(再生中なのに)割り込んで読まれる」ということはなくなるかと思います。