### PR TITLE
feat: 絵文字のエイリアスに対応

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
@@ -44,7 +44,6 @@ public class Event_SpeakVCText extends ListenerAdapter {
         if (content.equals(".")) {
             return; // .のみは除外
         }
-
         if (guild.getSelfMember().getVoiceState() == null ||
             guild.getSelfMember().getVoiceState().getChannel() == null) {
             // 自身がどこにも入っていない場合

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -249,7 +249,7 @@ public class VoiceText {
             return;
         }
 
-        vtFlow.success("[VoiceText.play] %s by %s (%s)", message.getContentDisplay().length() >= 10 ? message.getContentDisplay().substring(0, 10) : message.getContentDisplay(), message.getAuthor().getAsTag(), speakFromType.name());
+        vtFlow.success("[VoiceText.play] %s by %s (%s)", speakText.length() >= 10 ? speakText.substring(0, 10) : speakText, message.getAuthor().getAsTag(), speakFromType.name());
 
         VoiceText vt;
         try {

--- a/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/DefaultMessageProcessor.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/MessageProcessor/DefaultMessageProcessor.java
@@ -1,9 +1,6 @@
 package com.jaoafa.jdavcspeaker.MessageProcessor;
 
-import com.jaoafa.jdavcspeaker.Lib.EmojiWrapper;
-import com.jaoafa.jdavcspeaker.Lib.LibIgnore;
-import com.jaoafa.jdavcspeaker.Lib.UserVoiceTextResult;
-import com.jaoafa.jdavcspeaker.Lib.VoiceText;
+import com.jaoafa.jdavcspeaker.Lib.*;
 import com.jaoafa.jdavcspeaker.Main;
 import com.jaoafa.jdavcspeaker.Player.TrackInfo;
 import net.dv8tion.jda.api.JDA;
@@ -84,13 +81,15 @@ public class DefaultMessageProcessor implements BaseProcessor {
 
     @Override
     public void execute(JDA jda, Guild guild, TextChannel channel, Member member, Message message, UserVoiceTextResult uvtr) {
-        speak(jda, guild, message, uvtr, message.getContentDisplay());
+        speak(jda, guild, message, uvtr, message.getContentRaw());
     }
 
-    public void speak(JDA jda, Guild guild, Message message, UserVoiceTextResult uvtr, String speakContent) {
-        if (LibIgnore.isIgnoreMessage(speakContent)) {
+    public void speak(JDA jda, Guild guild, Message message, UserVoiceTextResult uvtr, String rawContent) {
+        if (LibIgnore.isIgnoreMessage(rawContent)) {
             return;
         }
+
+        String speakContent = MsgFormatter.getDisplayContent(message, true, false, true, true);
 
         // Replace discord invite(include event) url
         speakContent = replacerDiscordInviteLink(jda, guild, speakContent);


### PR DESCRIPTION
- `Message.getDisplayContent()` を使わずに、カスタムできる `getDisplayContent()` を作成
- エイリアスの適用タイミングを変更
- `/alias add` および `/alias remove`、`/alias list` 時の表示処理を調整し、絵文字のみの場合はその絵文字をそのまま表示するように
  - ただし、Botが参加していないサーバのサーバ絵文字は表示できないためその旨を表記するように