### PR TITLE
fix: PlayerManagerの完全static化、退出後の読み上げ停止

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Clear.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Clear.java
@@ -33,8 +33,8 @@ public class Cmd_Clear implements CmdSubstrate {
     }
 
     void clear(Guild guild, SlashCommandInteractionEvent event) {
-        PlayerManager.getINSTANCE().getGuildMusicManager(guild).scheduler.queue.clear();
-        PlayerManager.getINSTANCE().getGuildMusicManager(guild).player.destroy();
+        PlayerManager.getGuildMusicManager(guild).scheduler.queue.clear();
+        PlayerManager.getGuildMusicManager(guild).player.destroy();
 
         cmdFlow.success("%s が読み上げキューをクリアしました。", event.getUser().getAsTag());
         event.replyEmbeds(new EmbedBuilder()

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Disconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Disconnect.java
@@ -3,6 +3,7 @@ package com.jaoafa.jdavcspeaker.Command;
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdDetail;
 import com.jaoafa.jdavcspeaker.Framework.Command.CmdSubstrate;
 import com.jaoafa.jdavcspeaker.Lib.LibEmbedColor;
+import com.jaoafa.jdavcspeaker.Player.PlayerManager;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
@@ -55,7 +56,9 @@ public class Cmd_Disconnect implements CmdSubstrate {
             return;
         }
 
+        PlayerManager.destroyGuildMusicManager(event.getGuild());
         guild.getAudioManager().closeAudioConnection();
+
         cmdFlow.success("%s が %s から切断するようリクエストしました。", event.getUser().getAsTag(), connectedChannel.getName());
 
         event.replyEmbeds(new EmbedBuilder()

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Skip.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Skip.java
@@ -34,7 +34,7 @@ public class Cmd_Skip implements CmdSubstrate {
     }
 
     void skip(Guild guild, SlashCommandInteractionEvent event) {
-        TrackScheduler scheduler = PlayerManager.getINSTANCE().getGuildMusicManager(guild).scheduler;
+        TrackScheduler scheduler = PlayerManager.getGuildMusicManager(guild).scheduler;
         if (scheduler.queue.isEmpty()) {
             scheduler.player.destroy();
         } else {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoDisconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoDisconnect.java
@@ -43,7 +43,7 @@ public class AutoDisconnect extends ListenerAdapter {
         }
         new LibFlow("AutoDisconnect").success("退出に伴い、VCから誰もいなくなったため切断します。");
 
-        PlayerManager.getINSTANCE().destroyGuildMusicManager(event.getGuild());
+        PlayerManager.destroyGuildMusicManager(event.getGuild());
         event.getGuild().getAudioManager().closeAudioConnection();
 
         if (MultipleServer.getVCChannel(event.getGuild()) == null) return;

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_DeletedMessage.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_DeletedMessage.java
@@ -19,7 +19,7 @@ public class Event_DeletedMessage extends ListenerAdapter {
         }
         final Guild guild = event.getGuild();
         final long messageId = event.getMessageIdLong();
-        GuildMusicManager musicManager = PlayerManager.getINSTANCE().getGuildMusicManager(guild);
+        GuildMusicManager musicManager = PlayerManager.getGuildMusicManager(guild);
 
         new LibFlow("DeletedMessage").action("メッセージ(ID: " + messageId + ")が削除されました。");
 

--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_Disconnect.java
@@ -54,7 +54,14 @@ public class Event_Disconnect extends ListenerAdapter {
             .sendMessage("%s移動先を探しています…。".formatted(defaultContent))
             .complete();
 
-        if (!event.getMember().getUser().isBot()) {
+        // VCに残ったユーザーが全員Bot、または誰もいなくなった
+        boolean existsUser = event
+            .getChannelLeft()
+            .getMembers()
+            .stream()
+            .anyMatch(member -> !member.getUser().isBot()); // Bot以外がいるかどうか
+
+        if (!event.getMember().getUser().isBot() && existsUser) {
             new VoiceText().play(
                 TrackInfo.SpeakFromType.QUITED_VC,
                 message,

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -326,7 +326,7 @@ public class VoiceText {
         if (LibFiles.VDirectory.VOICETEXT_CACHES.exists(fileName)) {
             filteringQueue(speakFromType, message);
             TrackInfo info = new TrackInfo(speakFromType, message);
-            PlayerManager.getINSTANCE().loadAndPlay(
+            PlayerManager.loadAndPlay(
                 info,
                 LibFiles.VDirectory.VOICETEXT_CACHES.resolve(fileName).toString()
             );
@@ -389,14 +389,14 @@ public class VoiceText {
                 .queue();
             filteringQueue(speakFromType, message);
             TrackInfo info = new TrackInfo(speakFromType, message);
-            PlayerManager.getINSTANCE().loadAndPlay(info, LibFiles.VDirectory.VOICETEXT_CACHES.resolve(hashFileName).toString());
+            PlayerManager.loadAndPlay(info, LibFiles.VDirectory.VOICETEXT_CACHES.resolve(hashFileName).toString());
         } catch (JSONException e) {
             e.printStackTrace();
         }
     }
 
     private void filteringQueue(TrackInfo.SpeakFromType speakFromType, Message message) {
-        GuildMusicManager musicManager = PlayerManager.getINSTANCE().getGuildMusicManager(message.getGuild());
+        GuildMusicManager musicManager = PlayerManager.getGuildMusicManager(message.getGuild());
         Map<TrackInfo.SpeakFromType, List<TrackInfo.SpeakFromType>> filterRules = new HashMap<>();
         // VC退出時、参加・移動メッセージ読み上げを削除する
         filterRules.put(TrackInfo.SpeakFromType.QUITED_VC,

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/PlayerManager.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/PlayerManager.java
@@ -13,26 +13,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PlayerManager {
-    private static PlayerManager INSTANCE;
-    private final AudioPlayerManager playerManager;
-    private final Map<Long, GuildMusicManager> musicManagers;
+    private static final AudioPlayerManager playerManager;
+    private static final Map<Long, GuildMusicManager> musicManagers = new HashMap<>();
 
-
-    private PlayerManager() {
-        this.musicManagers = new HashMap<>();
-        this.playerManager = new DefaultAudioPlayerManager();
+    static {
+        playerManager = new DefaultAudioPlayerManager();
         AudioSourceManagers.registerRemoteSources(playerManager);
         AudioSourceManagers.registerLocalSource(playerManager);
     }
 
-    public static synchronized PlayerManager getINSTANCE() {
-        if (INSTANCE == null) {
-            INSTANCE = new PlayerManager();
-        }
-        return INSTANCE;
-    }
-
-    public synchronized GuildMusicManager getGuildMusicManager(Guild guild) {
+    public static GuildMusicManager getGuildMusicManager(Guild guild) {
         long guildID = guild.getIdLong();
         GuildMusicManager musicManager = musicManagers.get(guildID);
         if (musicManager == null) {
@@ -43,12 +33,12 @@ public class PlayerManager {
         return musicManager;
     }
 
-    public synchronized void destroyGuildMusicManager(Guild guild) {
+    public static void destroyGuildMusicManager(Guild guild) {
         getGuildMusicManager(guild).player.destroy();
         musicManagers.remove(guild.getIdLong());
     }
 
-    public void loadAndPlay(TrackInfo info, String trackUrl) {
+    public static void loadAndPlay(TrackInfo info, String trackUrl) {
         GuildMusicManager musicManager = getGuildMusicManager(info.getMessage().getGuild());
         playerManager.loadItemOrdered(musicManager, trackUrl, new AudioLoadResultHandler() {
             @Override
@@ -75,8 +65,11 @@ public class PlayerManager {
         });
     }
 
-    private void play(GuildMusicManager musicManager, AudioTrack track) {
+    private static void play(GuildMusicManager musicManager, AudioTrack track) {
         musicManager.scheduler.queue(track);
     }
 
+    public static Map<Long, GuildMusicManager> getMusicManagers() {
+        return musicManagers;
+    }
 }

--- a/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Player/TrackScheduler.java
@@ -120,5 +120,9 @@ public class TrackScheduler extends AudioEventAdapter {
         }
         return true;
     }
+
+    public BlockingQueue<AudioTrack> getQueue() {
+        return queue;
+    }
 }
 


### PR DESCRIPTION
https://github.com/jaoafa/jao-Minecraft-Server/issues/143 の解決追加PRです。

- PlayerManager.destroy() 後にも継続して managers に当該キーが残り続けてるように見えたので、#209 をさらに追修正する形の内容となります。
- 読みやすくするため、PlayerManager にあるメソッドを全て static にしました。（内容的にわざわざインスタンスとして持っている理由が無いと判断）
- AutoDisconnected 後、必ずひとつ以上の読み上げキューが残る問題を暫定的に修正しました。これは同時に抜けた一般ユーザ分の退出読み上げが残るために起きる問題です。但し、同時に複数人がVCから抜けた場合この問題は必ず発生するので、根本的な設計部分 https://github.com/jaoafa/JDA-VCSpeaker/issues/145#issuecomment-1401153299 を実装し直さなければ直りません。
- デバッグ用として `/vcspeaker debug queue` を追加

絶対設計レベルからなんとかするべき問題がいくつかあるけど、私には時間がない…