### PR TITLE
feat: Markdownの見出し文字（#）に応じて音量とスピードを変更する

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VoiceText.java
@@ -28,6 +28,7 @@ public class VoiceText {
     Emotion emotion = null;
     EmotionLevel emotionLevel = EmotionLevel.NORMAL;
     int pitch = 100;
+    int volume = 100;
     final LibFlow vtFlow = new LibFlow("VoiceText");
 
     /**
@@ -161,6 +162,28 @@ public class VoiceText {
             throw new WrongPitchException();
         }
         this.pitch = pitch;
+        return this;
+    }
+
+    public int getVolume() {
+        return volume;
+    }
+
+    /**
+     * Set the volume
+     *
+     * @param volume Volume
+     *
+     * @return VoiceText object after the volume has been set
+     *
+     * @throws WrongVolumeException if the value is incorrect
+     */
+    @CheckReturnValue
+    public VoiceText setVolume(int volume) throws WrongVolumeException {
+        if (volume < 50 || volume > 200) {
+            throw new WrongVolumeException();
+        }
+        this.volume = volume;
         return this;
     }
 
@@ -350,6 +373,7 @@ public class VoiceText {
                 .add("speaker", speaker.name().toLowerCase())
                 .add("speed", String.valueOf(speed))
                 .add("pitch", String.valueOf(pitch))
+                .add("volume", String.valueOf(volume))
                 .add("format", "mp3");
             if (emotion != null && emotionLevel != null) {
                 form.add("emotion", emotion.name().toLowerCase());
@@ -535,6 +559,11 @@ public class VoiceText {
 
     public static class WrongSpeedException extends WrongException {
         public WrongSpeedException() {
+        }
+    }
+
+    public static class WrongVolumeException extends WrongException {
+        public WrongVolumeException() {
         }
     }
 }


### PR DESCRIPTION
- close #216 

---

- 太字のスロー読み上げを 1.75 から 1.30 に緩和
- `# ` から始まる文字列の場合、以下のフローで読み上げ処理を変更
  - `#` がひとつ: 音量200% / 太字同様 1.30 の読み上げスピード低下
  - `#` がふたつ: 音量175%
  - `#` がみっつ: 音量150%