### PR TITLE
feat: メッセージがVCテキストチャンネルに送信された場合に自動参加する機能の無効化オプションを追加

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/Event_SpeakVCText.java
@@ -1,6 +1,7 @@
 package com.jaoafa.jdavcspeaker.Event;
 
 import com.jaoafa.jdavcspeaker.Lib.*;
+import com.jaoafa.jdavcspeaker.Main;
 import com.jaoafa.jdavcspeaker.MessageProcessor.BaseProcessor;
 import com.jaoafa.jdavcspeaker.MessageProcessor.ProcessorType;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -53,9 +54,10 @@ public class Event_SpeakVCText extends ListenerAdapter {
             guild.getSelfMember().getVoiceState().getChannel() == null) {
             // 自身がどこにも入っていない場合
 
-            if (member.getVoiceState() != null &&
+            if (!Main.getArgs().isDisableAutoJoinByMessage &&
+                member.getVoiceState() != null &&
                 member.getVoiceState().getChannel() != null) {
-                // メッセージ送信者がどこかのVCに入っている場合
+                // メッセージ送信者がどこかのVCに入っている場合（機能が有効な場合に限る）
 
                 guild.getAudioManager().openAudioConnection(member.getVoiceState().getChannel()); // 参加
                 if (MultipleServer.getVCChannel(guild) != null) {

--- a/src/main/java/com/jaoafa/jdavcspeaker/Lib/VCSpeakerArgs.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Lib/VCSpeakerArgs.java
@@ -23,8 +23,12 @@ public class VCSpeakerArgs {
     public boolean isOnlyRemoveCmd;
 
     @Option(name = "--disable-auto-join",
-            usage = "VCへの自動参加を無効化")
+            usage = "ユーザのVC参加によるVCへの自動参加を無効化")
     public boolean isDisableAutoJoin;
+
+    @Option(name = "--disable-auto-join-by-message",
+            usage = "メッセージ送信によるVCへの自動参加を無効化")
+    public boolean isDisableAutoJoinByMessage;
 
     @Option(name = "--disable-auto-move",
             usage = "VC間の自動移動を無効化")


### PR DESCRIPTION
- close https://github.com/jaoafa/JDA-VCSpeaker/issues/222

起動時に `--disable-auto-join-by-message` フラグをつけることで、以下の条件でVCSpeakerが参加する機能の無効化ができるようになります。

- vcテキストチャットへメッセージが投稿される
- 投稿者がどこかのvcにいる
- vcspeakerがvc参加していない
