### PR TITLE
feat: 一部のコマンドで管理者権限を必要としていたものをサーバ管理権限まで下げた

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Vcname.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Vcname.java
@@ -45,7 +45,7 @@ public class Cmd_Vcname implements CmdSubstrate {
 
 
     void save(Member member, SlashCommandInteractionEvent event) {
-        if (!member.getId().equals("492088741167366144") && !member.hasPermission(Permission.ADMINISTRATOR)) {
+        if (!member.hasPermission(Permission.MANAGE_SERVER)) {
             event.replyEmbeds(new EmbedBuilder()
                 .setTitle(":no_pedestrians: 実行する権限がありません！")
                 .setColor(LibEmbedColor.error)
@@ -90,7 +90,7 @@ public class Cmd_Vcname implements CmdSubstrate {
     }
 
     void saveall(Guild guild, Member member, SlashCommandInteractionEvent event) {
-        if (!member.getId().equals("492088741167366144") && !member.hasPermission(Permission.ADMINISTRATOR)) {
+        if (!member.hasPermission(Permission.MANAGE_SERVER)) {
             event.replyEmbeds(new EmbedBuilder()
                 .setTitle(":no_pedestrians: 実行する権限がありません！")
                 .setColor(LibEmbedColor.error)

--- a/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Vcspeaker.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Command/Cmd_Vcspeaker.java
@@ -29,7 +29,7 @@ public class Cmd_Vcspeaker implements CmdSubstrate {
     final EmbedBuilder NO_PERMISSION =
         new EmbedBuilder()
             .setDescription("""
-                あなたは管理者権限を所持していないため、
+                あなたはサーバ管理権限を所持していないため、
                 このサーバでVCSpeakerの設定をすることはできません。
                 """)
             .setColor(LibEmbedColor.error);
@@ -72,7 +72,7 @@ public class Cmd_Vcspeaker implements CmdSubstrate {
     }
 
     void addServer(Guild guild, GuildMessageChannel channel, Member member, SlashCommandInteractionEvent event) {
-        if (!member.hasPermission(Permission.ADMINISTRATOR)) {
+        if (!member.hasPermission(Permission.MANAGE_SERVER)) {
             event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
         }
@@ -110,7 +110,7 @@ public class Cmd_Vcspeaker implements CmdSubstrate {
     }
 
     void removeServer(Guild guild, Member member, SlashCommandInteractionEvent event) {
-        if (!member.hasPermission(Permission.ADMINISTRATOR)) {
+        if (!member.hasPermission(Permission.MANAGE_SERVER)) {
             event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
         }
@@ -133,7 +133,7 @@ public class Cmd_Vcspeaker implements CmdSubstrate {
     }
 
     void setNotifyChannel(Guild guild, Member member, SlashCommandInteractionEvent event) {
-        if (!member.hasPermission(Permission.ADMINISTRATOR)) {
+        if (!member.hasPermission(Permission.MANAGE_SERVER)) {
             event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
         }
@@ -170,7 +170,7 @@ public class Cmd_Vcspeaker implements CmdSubstrate {
     }
 
     void showDebugQueue(Member member, SlashCommandInteractionEvent event) {
-        if (!member.hasPermission(Permission.ADMINISTRATOR)) {
+        if (!member.hasPermission(Permission.MANAGE_SERVER)) {
             event.replyEmbeds(NO_PERMISSION.build()).queue();
             return;
         }


### PR DESCRIPTION
表題のとおり。

以下のコマンドで、必要とする権限のレベルを下げました。jaoであれば、モデレーターもこれらのコマンドが実行できるようになるはずです。

- `/vcspeaker` 関連のコマンド
- `/vcname save`, `/vcname saveall`

なお、この修正をせざるを得なくなったのはFrにVCSpeakerを導入したためです…