### PR TITLE
fix: disconnection when someone moves to afk

### DIFF
--- a/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoMove.java
+++ b/src/main/java/com/jaoafa/jdavcspeaker/Event/AutoMove.java
@@ -71,11 +71,12 @@ public class AutoMove extends ListenerAdapter {
 
         if (isAfkChannel(newChannel)) {
             // VCに残ったユーザーが全員Bot、または誰もいなくなった
-            boolean existsUser = newChannel
+            boolean existsUser = oldChannel
                 .getMembers()
                 .stream()
                 .anyMatch(member -> !member.getUser().isBot()); // Bot以外がいるかどうか
-            if (!existsUser) {
+
+            if (existsUser) {
                 return;
             }
 


### PR DESCRIPTION
close #232 

まだユーザがVCに滞在しているのに、AFKに移動したユーザーがいる場合、VCWatcherが退出してしまう問題を解決しました。  
あと少しで VCSpeaker.kt がいい感じになりそうなのでコードの整理とかはしてません。